### PR TITLE
Requests signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ tmp_*
 
 # Contribution artifacts
 *.params
-keypair
+*keypair

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tmp_*
 
 # Contribution artifacts
 *.params
+keypair

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ dependencies = [
  "rocket",
  "rustc_version",
  "serde",
+ "serde_json",
  "setup-utils",
  "snarkvm-curves 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "structopt",

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	$(CARGO) build
 
 check:
-	$(CARGO) check
+	$(CARGO) check --all-targets
 
 contribution: # Run contributor against a local coordinator (127.0.0.1:8000)
 	RUST_LOG=debug $(CARGO) run $(CLI_FLAGS) contribute

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,6 @@ update:
 	$(CARGO) update
 
 clean:
-	$(CARGO) clean
+	$(CARGO) clean --release
 
 .PHONY : build check clean clippy close-ceremony contribution fmt contributor run-coordinator test-coordinator test-e2e update

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -25,6 +25,7 @@ hex = { version = "0.4.2" }
 memmap = { version = "0.7.0" }
 rand = { version = "0.8" }
 reqwest = { version = "0.11", features = ["json"] }
+serde_json = "1.0.81"
 structopt = "0.3"
 thiserror = "1.0.30"
 tokio = "1.17.0"

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -111,7 +111,7 @@ async fn do_contribute(client: &Client, coordinator: &mut Url, sigkey: &str, pub
     debug!("Challenge hash is {}", pretty_hash!(&challenge_hash));
     debug!("Challenge length {}", challenge.len());
 
-    let contribution = compute_contribution(
+    let contribution = compute_contribution( //FIXME: spawn_blocking? Try to measure the speed
         pubkey,
         round_height,
         &challenge,
@@ -238,3 +238,6 @@ async fn main() {
         }
     }
 }
+
+// FIXME: fix call to requests
+// FIXME: fix tests

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -1,10 +1,10 @@
 use phase1_coordinator::{
-    COORDINATOR_KEYPAIR_FILE,
     authentication::{KeyPair, Production, Signature},
     commands::Computation,
     objects::{round::LockedLocators, ContributionFileSignature, ContributionState, Task},
     rest::{ContributorStatus, PostChunkRequest, UPDATE_TIME},
     storage::{ContributionLocator, Object},
+    COORDINATOR_KEYPAIR_FILE,
 };
 
 use reqwest::{Client, Url};
@@ -12,9 +12,9 @@ use reqwest::{Client, Url};
 use crate::requests::RequestError;
 use anyhow::Result;
 use phase1_cli::{requests, ContributorOpt};
+use serde_json;
 use setup_utils::calculate_hash;
 use structopt::StructOpt;
-use serde_json;
 
 use std::{
     fs::File,
@@ -66,7 +66,7 @@ fn get_keypair(coordinator: bool) -> Result<KeyPair> {
             f.read_to_string(&mut keypair_str)?;
 
             Ok(serde_json::from_str(keypair_str.as_str())?)
-        },
+        }
         Err(_) => {
             info!("Missing keypair file, generating new one");
             let keypair = KeyPair::new();
@@ -77,7 +77,7 @@ fn get_keypair(coordinator: bool) -> Result<KeyPair> {
             f.write_all(&serde_json::to_vec(&keypair)?)?;
 
             Ok(keypair)
-        },
+        }
     }
 }
 

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -20,7 +20,7 @@ pub use transform_ratios::transform_ratios;
 
 use phase1_coordinator::{
     objects::{round::LockedLocators, Task},
-    rest::{ContributeChunkRequest, ContributorStatus, GetChunkRequest, PostChunkRequest},
+    rest::{ContributeChunkRequest, ContributorStatus, GetChunkRequest, PostChunkRequest, SignedRequest},
     storage::ContributionLocator,
 };
 

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -20,7 +20,7 @@ pub use transform_ratios::transform_ratios;
 
 use phase1_coordinator::{
     objects::{round::LockedLocators, Task},
-    rest::{ContributeChunkRequest, ContributorStatus, GetChunkRequest, PostChunkRequest, SignedRequest},
+    rest::{ContributorStatus, PostChunkRequest},
     storage::ContributionLocator,
 };
 

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -1,18 +1,12 @@
 //! Requests sent to the [Coordinator](`phase1-coordinator::Coordinator`) server.
 
-use phase1_coordinator::{rest::SignedRequest, authentication::KeyPair};
+use phase1_coordinator::{authentication::KeyPair, rest::SignedRequest};
 use reqwest::{Client, Method, Response, Url};
 use serde::Serialize;
 use std::collections::LinkedList;
 use thiserror::Error;
 
-use crate::{
-    ContributionLocator,
-    ContributorStatus,
-    LockedLocators,
-    PostChunkRequest,
-    Task,
-};
+use crate::{ContributionLocator, ContributorStatus, LockedLocators, PostChunkRequest, Task};
 
 /// Error returned from a request. Could be due to a Client or Server error.
 #[derive(Debug, Error)]
@@ -56,8 +50,7 @@ where
 }
 
 /// Send a request to the [Coordinator](`phase1-coordinator::Coordinator`) to join the queue of contributors.
-pub async fn post_join_queue(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()>
-{
+pub async fn post_join_queue(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> {
     submit_request::<String>(
         client,
         coordinator_address,
@@ -76,8 +69,7 @@ pub async fn post_lock_chunk(
     client: &Client,
     coordinator_address: &mut Url,
     keypair: &KeyPair,
-) -> Result<LockedLocators>
-{
+) -> Result<LockedLocators> {
     let response = submit_request::<String>(
         client,
         coordinator_address,
@@ -92,8 +84,12 @@ pub async fn post_lock_chunk(
 }
 
 /// Send a request to the [Coordinator](`phase1-coordinator::Coordinator`) to get the next [Chunk](`phase1-coordinator::objects::Chunk`).
-pub async fn get_chunk(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair, request_body: &LockedLocators) -> Result<Task>
-{
+pub async fn get_chunk(
+    client: &Client,
+    coordinator_address: &mut Url,
+    keypair: &KeyPair,
+    request_body: &LockedLocators,
+) -> Result<Task> {
     let response = submit_request(
         client,
         coordinator_address,
@@ -113,8 +109,7 @@ pub async fn get_challenge(
     coordinator_address: &mut Url,
     keypair: &KeyPair,
     request_body: &LockedLocators,
-) -> Result<Vec<u8>>
-{
+) -> Result<Vec<u8>> {
     let response = submit_request(
         client,
         coordinator_address,
@@ -129,8 +124,12 @@ pub async fn get_challenge(
 }
 
 /// Send a request to the [Coordinator](`phase1-coordinator::Coordinator`) to upload a contribution.
-pub async fn post_chunk(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair, request_body: &PostChunkRequest) -> Result<()>
-{
+pub async fn post_chunk(
+    client: &Client,
+    coordinator_address: &mut Url,
+    keypair: &KeyPair,
+    request_body: &PostChunkRequest,
+) -> Result<()> {
     submit_request(
         client,
         coordinator_address,
@@ -150,8 +149,7 @@ pub async fn post_contribute_chunk(
     coordinator_address: &mut Url,
     keypair: &KeyPair,
     request_body: u64,
-) -> Result<ContributionLocator>
-{
+) -> Result<ContributionLocator> {
     let response = submit_request(
         client,
         coordinator_address,
@@ -166,8 +164,7 @@ pub async fn post_contribute_chunk(
 }
 
 /// Let the [Coordinator](`phase1-coordinator::Coordinator`) know that the contributor is still alive.
-pub async fn post_heartbeat(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()>
-{
+pub async fn post_heartbeat(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> {
     submit_request::<String>(
         client,
         coordinator_address,
@@ -185,9 +182,8 @@ pub async fn post_heartbeat(client: &Client, coordinator_address: &mut Url, keyp
 pub async fn get_tasks_left(
     client: &Client,
     coordinator_address: &mut Url,
-    keypair: &KeyPair
-) -> Result<LinkedList<Task>>
-{
+    keypair: &KeyPair,
+) -> Result<LinkedList<Task>> {
     let response = submit_request::<String>(
         client,
         coordinator_address,
@@ -203,16 +199,14 @@ pub async fn get_tasks_left(
 
 /// Request an update of the [Coordinator](`phase1-coordinator::Coordinator`) state.
 #[cfg(debug_assertions)]
-pub async fn get_update(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> 
-{
+pub async fn get_update(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> {
     submit_request::<()>(client, coordinator_address, "/update", keypair, None, &Method::GET).await?;
 
     Ok(())
 }
 
 /// Stop the [Coordinator](`phase1-coordinator::Coordinator`).
-pub async fn get_stop_coordinator(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()>
-{
+pub async fn get_stop_coordinator(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> {
     submit_request::<()>(client, coordinator_address, "/stop", keypair, None, &Method::GET).await?;
 
     Ok(())
@@ -220,8 +214,7 @@ pub async fn get_stop_coordinator(client: &Client, coordinator_address: &mut Url
 
 /// Verify the pending contributions.
 #[cfg(debug_assertions)]
-pub async fn get_verify_chunks(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()>
-{
+pub async fn get_verify_chunks(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<()> {
     submit_request::<()>(client, coordinator_address, "/verify", keypair, None, &Method::GET).await?;
 
     Ok(())
@@ -232,8 +225,7 @@ pub async fn get_contributor_queue_status(
     client: &Client,
     coordinator_address: &mut Url,
     keypair: &KeyPair,
-) -> Result<ContributorStatus>
-{
+) -> Result<ContributorStatus> {
     let response = submit_request::<()>(
         client,
         coordinator_address,

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -45,26 +45,7 @@ where
     };
 
     // Sign the request
-    let body = match request_body {
-        Some(body) => {
-            let signature = SignedRequest::sign(keypair, Some(&body)).map_err(|e| RequestError::Server(format!("{}", e)))?;
-
-            SignedRequest {
-                request: Some(body),
-                signature,
-                pubkey: keypair.pubkey().to_owned()
-            }
-        }, 
-        None => {
-            // If the request has no body use the pubkey as body to sign
-            SignedRequest {
-                request: None,
-                signature: SignedRequest::<()>::sign(keypair, None).map_err(|e| RequestError::Server(format!("{}", e)))?,
-                pubkey: keypair.pubkey().to_owned()
-            }
-        },
-    };
-
+    let body = SignedRequest::try_sign(keypair, request_body).map_err(|e| RequestError::Server(format!("{}", e)))?;
     let response = req.json(&body).send().await?;
 
     if response.status().is_success() {

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use serde::{Deserialize, Serialize};
 
 /// A private/public key couple encoded in [`base64`]
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct KeyPair {
     pubkey: String,
     sigkey: String,

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -3,8 +3,10 @@ use base64;
 use ed25519_compact::{KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Signature};
 use hex;
 use std::ops::Deref;
+use serde::{Deserialize, Serialize};
 
 /// A private/public key couple encoded in [`base64`]
+#[derive(Deserialize, Serialize)]
 pub struct KeyPair {
     pubkey: String,
     sigkey: String,

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -23,6 +23,15 @@ impl KeyPair {
         }
     }
 
+    /// Custom keypair available only in test
+    #[cfg(debug_assertions)]
+    pub fn custom_new(sigkey: String, pubkey: String) -> Self {
+        KeyPair {
+            pubkey,
+            sigkey
+        }
+    }
+
     /// Get a reference to the key pair's pubkey.
     #[must_use]
     pub fn pubkey(&self) -> &str {

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -2,8 +2,8 @@ use crate::authentication::Signature as SigTrait;
 use base64;
 use ed25519_compact::{KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Signature};
 use hex;
-use std::ops::Deref;
 use serde::{Deserialize, Serialize};
+use std::ops::Deref;
 
 /// A private/public key couple encoded in [`base64`]
 #[derive(Debug, Deserialize, Serialize)]
@@ -26,10 +26,7 @@ impl KeyPair {
     /// Custom keypair available only in test
     #[cfg(debug_assertions)]
     pub fn custom_new(sigkey: String, pubkey: String) -> Self {
-        KeyPair {
-            pubkey,
-            sigkey
-        }
+        KeyPair { pubkey, sigkey }
     }
 
     /// Get a reference to the key pair's pubkey.

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use std::{fs::File, io::Write};
 
-pub const KEYPAIR_FILE: &str = "keypair";
+pub const COORDINATOR_KEYPAIR_FILE: &str = "coordinator.keypair";
 
 type BatchSize = usize;
 type ChunkSize = usize;
@@ -593,7 +593,7 @@ impl std::default::Default for Testing {
     fn default() -> Self {
         // Generate default verifier of coordinator and writes it to file FIXME: export to function
         let keypair = KeyPair::new();
-        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        let mut f = File::create(COORDINATOR_KEYPAIR_FILE).expect("Error while creating keypair file");
         f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {
@@ -715,7 +715,7 @@ impl std::default::Default for Development {
     fn default() -> Self {
         // Generate default verifier of coordinator and writes it to file
         let keypair = KeyPair::new();
-        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        let mut f = File::create(COORDINATOR_KEYPAIR_FILE).expect("Error while creating keypair file");
         f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {
@@ -836,7 +836,7 @@ impl std::default::Default for Production {
     fn default() -> Self {
         // Generate default verifier of coordinator and writes it to file
         let keypair = KeyPair::new();
-        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        let mut f = File::create(COORDINATOR_KEYPAIR_FILE).expect("Error while creating keypair file");
         f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -5,6 +5,10 @@ use setup_utils::{CheckForCorrectness, UseCompression};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
+use std::{fs::File, io::Write};
+
+pub const KEYPAIR_FILE: &str = "keypair";
+
 type BatchSize = usize;
 type ChunkSize = usize;
 type NumberOfChunks = usize;
@@ -587,8 +591,10 @@ impl std::ops::Deref for Testing {
 
 impl std::default::Default for Testing {
     fn default() -> Self {
-        // Generate default verifier of coordinator
+        // Generate default verifier of coordinator and writes it to file FIXME: export to function
         let keypair = KeyPair::new();
+        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {
             environment: Environment {
@@ -707,8 +713,10 @@ impl std::ops::DerefMut for Development {
 
 impl std::default::Default for Development {
     fn default() -> Self {
-        // Generate default verifier of coordinator
+        // Generate default verifier of coordinator and writes it to file
         let keypair = KeyPair::new();
+        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {
             environment: Environment {
@@ -826,8 +834,10 @@ impl std::ops::Deref for Production {
 
 impl std::default::Default for Production {
     fn default() -> Self {
-        // Generate default verifier of coordinator
+        // Generate default verifier of coordinator and writes it to file
         let keypair = KeyPair::new();
+        let mut f = File::create(KEYPAIR_FILE).expect("Error while creating keypair file");
+        f.write_all(&serde_json::to_vec(&keypair).expect("Serialization failed")).expect("Error while writing keypair to file");
 
         Self {
             environment: Environment {

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -46,6 +46,7 @@ pub mod coordinator_state;
 pub use coordinator_state::CoordinatorState;
 
 pub mod environment;
+pub use environment::KEYPAIR_FILE;
 
 pub mod objects;
 pub use objects::{ContributionFileSignature, ContributionState, Participant, Round};

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -46,7 +46,7 @@ pub mod coordinator_state;
 pub use coordinator_state::CoordinatorState;
 
 pub mod environment;
-pub use environment::KEYPAIR_FILE;
+pub use environment::COORDINATOR_KEYPAIR_FILE;
 
 pub mod objects;
 pub use objects::{ContributionFileSignature, ContributionState, Participant, Round};

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -186,6 +186,8 @@ impl PostChunkRequest {
 // -- REST API ENDPOINTS --
 //
 
+// FIXME: check wich spawn_blocking are necesessary
+
 /// Add the incoming contributor to the queue of contributors.
 #[post("/contributor/join_queue", format = "json", data = "<request>")]
 pub async fn join_queue(

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -1,7 +1,7 @@
 //! REST API endpoints exposed by the [Coordinator](`crate::Coordinator`).
 
 use crate::{
-    authentication::{Production, Signature},
+    authentication::{KeyPair, Production, Signature},
     objects::Task,
     storage::{ContributionLocator, ContributionSignatureLocator},
     ContributionFileSignature,
@@ -49,10 +49,14 @@ pub enum ResponseError {
     InvalidSignature,
     #[error("Thread panicked: {0}")]
     RuntimeError(#[from] task::JoinError),
+    #[error("Error with Serde: {0}")]
+    SerdeError(#[from] serde_json::error::Error),
     #[error("Error while signing the request: {0}")]
     SigningError(String),
     #[error("Error while terminating the ceremony: {0}")]
     ShutdownError(String),
+    #[error("The participant {0} is not allowed to access endpoint {1}")]
+    UnauthorizedParticipant(Participant, String),
     #[error("Could not find contributor with public key {0}")]
     UnknownContributor(String),
     #[error("Could not find the provided Task {0} in coordinator state")]
@@ -74,23 +78,37 @@ impl<'r> Responder<'r, 'static> for ResponseError {
 
 type Result<T> = std::result::Result<T, ResponseError>;
 
-// FIXME: remove unused struct and also their imports around
-
-/// A signed incoming request. Contains the pubkey to check the signature.
+/// A signed incoming request. Contains the pubkey to check the signature. If the
+/// request is None the signature is computed on the pubkey itself.
 /// Signature must be computed on the Json encoding of request and relies on
 /// the [`Production`] signature scheme  
 #[derive(Deserialize, Serialize)]
 pub struct SignedRequest<T>
 where T: Serialize
 {
-    pub request: T,
+    pub request: Option<T>,
     pub signature: String,
     pub pubkey: String,
 }
 
+impl<T: Serialize> Deref for SignedRequest<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match &self.request {
+            Some(t) => t,
+            None => panic!("Expected Some not None")
+        }
+    }
+}
+
 impl<T: Serialize> SignedRequest<T> {
     fn verify(&self) -> Result<()> {
-        let request = json::to_string(&self.request).unwrap(); //FIXME: manage error
+        let request = match &self.request {
+            Some(r) => json::to_string(r)?,
+            None => json::to_string(&self.pubkey)?,
+        };
+
         let sig_scheme = Production;
         
         if sig_scheme.verify(self.pubkey.as_str(), request.as_str(), self.signature.as_str()) {
@@ -100,11 +118,14 @@ impl<T: Serialize> SignedRequest<T> {
         }
     }
 
-    pub fn sign(request: &T, pubkey: &str) -> Result<String> {
-        let request = json::to_string(request).unwrap(); //FIXME: manage error
+    pub fn sign(keypair: &KeyPair, request: Option<&T>) -> Result<String> {
+        let request = match request {
+            Some(r) => json::to_string(r)?,
+            None => json::to_string(&keypair.pubkey().to_owned())?
+        };
         let sig_scheme = Production;
 
-        match sig_scheme.sign(pubkey, request.as_str()) {
+        match sig_scheme.sign(keypair.sigkey(), request.as_str()) {
             Ok(sig) => Ok(sig),
             Err(e) => Err(ResponseError::SigningError(format!("{}", e)))
         }
@@ -118,35 +139,6 @@ pub enum ContributorStatus {
     Round,
     Finished,
     Other,
-}
-
-/// Request to get a [Chunk](`crate::objects::Chunk`).
-#[derive(Deserialize, Serialize)]
-pub struct GetChunkRequest {
-    pubkey: String,
-    locked_locators: LockedLocators,
-}
-
-impl GetChunkRequest {
-    pub fn new(pubkey: String, locked_locators: LockedLocators) -> Self {
-        GetChunkRequest {
-            pubkey,
-            locked_locators,
-        }
-    }
-}
-
-/// Contribution of a [Chunk](`crate::objects::Chunk`).
-#[derive(Deserialize, Serialize)]
-pub struct ContributeChunkRequest {
-    pubkey: String,
-    chunk_id: u64,
-}
-
-impl ContributeChunkRequest {
-    pub fn new(pubkey: String, chunk_id: u64) -> Self {
-        Self { pubkey, chunk_id }
-    }
 }
 
 /// Request to post a [Chunk](`crate::objects::Chunk`).
@@ -174,22 +166,36 @@ impl PostChunkRequest {
     }
 }
 
+/// Check the signature of the request and also that the request comes from the
+/// [Coordinator](`crate::Coordinator`) itself.
+async fn check_coordinator_request<T>(coordinator: &Coordinator, signed_request: &SignedRequest<T>) -> Result<()>
+where T: Serialize {
+    // Check pubkey is the one of the coordinator's verifier
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_ref());
+    if contributor != coordinator.read().await.environment().coordinator_verifiers()[0] {
+        return Err(ResponseError::UnauthorizedParticipant(contributor, String::from("/update")));
+    }
+    // Check signature
+    signed_request.verify()
+}
+
 //
 // -- REST API ENDPOINTS --
 //
 
-// FIXME: enpoint should be public only for crate
-// FIXME: fix endpoints to handle SignedRequest
-
 /// Add the incoming contributor to the queue of contributors.
-#[post("/contributor/join_queue", format = "json", data = "<contributor_pubkey>")]
+#[post("/contributor/join_queue", format = "json", data = "<request>")]
 pub async fn join_queue(
     coordinator: &State<Coordinator>,
-    contributor_pubkey: Json<String>,
+    request: Json<SignedRequest<()>>,
     contributor_ip: SocketAddr,
 ) -> Result<()> {
-    let pubkey = contributor_pubkey.into_inner();
-    let contributor = Participant::new_contributor(pubkey.as_str());
+    let signed_request = request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_str());
 
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
@@ -200,13 +206,17 @@ pub async fn join_queue(
 }
 
 /// Lock a [Chunk](`crate::objects::Chunk`) in the ceremony. This should be the first function called when attempting to contribute to a chunk. Once the chunk is locked, it is ready to be downloaded.
-#[post("/contributor/lock_chunk", format = "json", data = "<contributor_pubkey>")]
+#[post("/contributor/lock_chunk", format = "json", data = "<request>")]
 pub async fn lock_chunk(
     coordinator: &State<Coordinator>,
-    contributor_pubkey: Json<String>,
+    request: Json<SignedRequest<()>>,
 ) -> Result<Json<LockedLocators>> {
-    let pubkey = contributor_pubkey.into_inner();
-    let contributor = Participant::new_contributor(pubkey.as_str());
+    let signed_request = request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_str());
 
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
@@ -224,13 +234,11 @@ pub async fn get_chunk(
 ) -> Result<Json<Task>> {
     let signed_request = get_chunk_request.into_inner();
 
-    // Check signature FIXME: this first part, into and sig verification could be done with a macro, or at least in a separate function
+    // Check signature
     signed_request.verify()?;
 
-    let locked_locators = signed_request.request;
     let contributor = Participant::new_contributor(signed_request.pubkey.as_ref());
-
-    let next_contribution = locked_locators.next_contribution();
+    let next_contribution = signed_request.next_contribution();
 
     // Build and check next Task
     let task = Task::new(next_contribution.chunk_id(), next_contribution.contribution_id());
@@ -252,11 +260,14 @@ pub async fn get_chunk(
 #[get("/contributor/challenge", format = "json", data = "<locked_locators>")]
 pub async fn get_challenge(
     coordinator: &State<Coordinator>,
-    locked_locators: Json<LockedLocators>,
+    locked_locators: Json<SignedRequest<LockedLocators>>,
 ) -> Result<Json<Vec<u8>>> {
-    let request = locked_locators.into_inner();
+    let signed_request = locked_locators.into_inner();
 
-    let challenge_locator = request.current_contribution();
+    // Check signature
+    signed_request.verify()?;
+
+    let challenge_locator = signed_request.current_contribution();
     let round_height = challenge_locator.round_height();
     let chunk_id = challenge_locator.chunk_id();
 
@@ -280,9 +291,14 @@ pub async fn get_challenge(
 #[post("/upload/chunk", format = "json", data = "<post_chunk_request>")]
 pub async fn post_contribution_chunk(
     coordinator: &State<Coordinator>,
-    post_chunk_request: Json<PostChunkRequest>,
+    post_chunk_request: Json<SignedRequest<PostChunkRequest>>,
 ) -> Result<()> {
-    let request = post_chunk_request.into_inner();
+    let signed_request = post_chunk_request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let request = signed_request.request.unwrap();
     let request_clone = request.clone();
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
@@ -315,14 +331,19 @@ pub async fn post_contribution_chunk(
 )]
 pub async fn contribute_chunk(
     coordinator: &State<Coordinator>,
-    contribute_chunk_request: Json<ContributeChunkRequest>,
+    contribute_chunk_request: Json<SignedRequest<u64>>,
 ) -> Result<Json<ContributionLocator>> {
-    let request = contribute_chunk_request.into_inner();
-    let contributor = Participant::new_contributor(request.pubkey.as_ref());
+    let signed_request = contribute_chunk_request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let chunk_id = signed_request.request.unwrap();
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_ref());
 
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
-    match task::spawn_blocking(move || write_lock.try_contribute(&contributor, request.chunk_id)).await? {
+    match task::spawn_blocking(move || write_lock.try_contribute(&contributor, chunk_id)).await? {
         Ok(contribution_locator) => Ok(Json(contribution_locator)),
         Err(e) => Err(ResponseError::CoordinatorError(e)),
     }
@@ -338,19 +359,28 @@ pub async fn perform_coordinator_update(coordinator: Coordinator) -> Result<()> 
     }
 }
 
-/// Update the [Coordinator](`crate::Coordinator`) state.
+/// Update the [Coordinator](`crate::Coordinator`) state. This endpoint should be accessible only by the coordinator itself.
 #[cfg(debug_assertions)]
-#[get("/update")]
-pub async fn update_coordinator(coordinator: &State<Coordinator>) -> Result<()> {
+#[get("/update", format = "json",
+data = "<request>")]
+pub async fn update_coordinator(coordinator: &State<Coordinator>, request: Json<SignedRequest<()>>) -> Result<()> {
+    let signed_request = request.into_inner();
+
+    // Verify request
+    check_coordinator_request(coordinator, &signed_request).await?;
+
     perform_coordinator_update(coordinator.deref().to_owned()).await
 }
 
 /// Let the [Coordinator](`crate::Coordinator`) know that the participant is still alive and participating (or waiting to participate) in the ceremony.
-#[post("/contributor/heartbeat", format = "json", data = "<contributor_pubkey>")]
-pub async fn heartbeat(coordinator: &State<Coordinator>, contributor_pubkey: Json<String>) -> Result<()> {
-    let pubkey = contributor_pubkey.into_inner();
-    let contributor = Participant::new_contributor(pubkey.as_str());
+#[post("/contributor/heartbeat", format = "json", data = "<request>")]
+pub async fn heartbeat(coordinator: &State<Coordinator>, request: Json<SignedRequest<()>>) -> Result<()> {
+    let signed_request = request.into_inner();
 
+    // Check signature
+    signed_request.verify()?;
+
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_str());
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
     match task::spawn_blocking(move || write_lock.heartbeat(&contributor)).await? {
@@ -360,25 +390,34 @@ pub async fn heartbeat(coordinator: &State<Coordinator>, contributor_pubkey: Jso
 }
 
 /// Get the pending tasks of contributor.
-#[get("/contributor/get_tasks_left", format = "json", data = "<contributor_pubkey>")]
+#[get("/contributor/get_tasks_left", format = "json", data = "<request>")]
 pub async fn get_tasks_left(
     coordinator: &State<Coordinator>,
-    contributor_pubkey: Json<String>,
+    request: Json<SignedRequest<()>>,
 ) -> Result<Json<LinkedList<Task>>> {
-    let pubkey = contributor_pubkey.into_inner();
-    let contributor = Participant::new_contributor(pubkey.as_str());
+    let signed_request = request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let contributor = Participant::new_contributor(signed_request.pubkey.as_str());
 
     let read_lock = (*coordinator).clone().read_owned().await;
 
     match task::spawn_blocking(move || read_lock.state().current_participant_info(&contributor).cloned()).await? {
         Some(info) => Ok(Json(info.pending_tasks().to_owned())),
-        None => Err(ResponseError::UnknownContributor(pubkey)),
+        None => Err(ResponseError::UnknownContributor(signed_request.pubkey)),
     }
 }
 
 /// Stop the [Coordinator](`crate::Coordinator`) and shuts the server down. This endpoint should be accessible only by the coordinator itself.
-#[get("/stop")]
-pub async fn stop_coordinator(coordinator: &State<Coordinator>, shutdown: Shutdown) -> Result<()> {
+#[get("/stop", format = "json", data = "<request>")]
+pub async fn stop_coordinator(coordinator: &State<Coordinator>, request: Json<SignedRequest<()>>, shutdown: Shutdown) -> Result<()> {
+    let signed_request = request.into_inner();
+
+    // Verify request
+    check_coordinator_request(coordinator, &signed_request).await?;
+
     let mut write_lock = (*coordinator).clone().write_owned().await;
 
     let result = task::spawn_blocking(move || write_lock.shutdown()).await?;
@@ -412,19 +451,28 @@ pub async fn perform_verify_chunks(coordinator: Coordinator) -> Result<()> {
 
 /// Verify all the pending contributions. This endpoint should be accessible only by the coordinator itself.
 #[cfg(debug_assertions)]
-#[get("/verify")]
-pub async fn verify_chunks(coordinator: &State<Coordinator>) -> Result<()> {
+#[get("/verify", format = "json", data = "<request>")]
+pub async fn verify_chunks(coordinator: &State<Coordinator>, request: Json<SignedRequest<()>>) -> Result<()> {
+    let signed_request = request.into_inner();
+
+    // Verify request
+    check_coordinator_request(coordinator, &signed_request).await?;
+
     perform_verify_chunks(coordinator.deref().to_owned()).await
 }
 
 /// Get the queue status of the contributor.
-#[get("/contributor/queue_status", format = "json", data = "<contributor_pubkey>")]
+#[get("/contributor/queue_status", format = "json", data = "<request>")]
 pub async fn get_contributor_queue_status(
     coordinator: &State<Coordinator>,
-    contributor_pubkey: Json<String>,
+    request: Json<SignedRequest<()>>,
 ) -> Result<Json<ContributorStatus>> {
-    let pubkey = contributor_pubkey.into_inner();
-    let contrib = Participant::new_contributor(pubkey.as_str());
+    let signed_request = request.into_inner();
+
+    // Check signature
+    signed_request.verify()?;
+
+    let contrib = Participant::new_contributor(signed_request.pubkey.as_str());
     let contributor = contrib.clone();
 
     let read_lock = (*coordinator).clone().read_owned().await;

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -86,9 +86,9 @@ type Result<T> = std::result::Result<T, ResponseError>;
 pub struct SignedRequest<T>
 where T: Serialize
 {
-    pub request: Option<T>,
-    pub signature: String,
-    pub pubkey: String,
+    request: Option<T>,
+    signature: String,
+    pubkey: String,
 }
 
 impl<T: Serialize> Deref for SignedRequest<T> {
@@ -185,8 +185,6 @@ where T: Serialize {
 //
 // -- REST API ENDPOINTS --
 //
-
-// FIXME: request guards for signature?
 
 /// Add the incoming contributor to the queue of contributors.
 #[post("/contributor/join_queue", format = "json", data = "<request>")]

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -45,7 +45,7 @@ struct TestCtx {
     rocket: Rocket<Build>,
     contributors: Vec<TestParticipant>,
     unknown_participant: TestParticipant,
-    coordinator: TestParticipant
+    coordinator: TestParticipant,
 }
 
 /// Build the rocket server for testing with the proper configuration.
@@ -76,13 +76,16 @@ fn build_context() -> TestCtx {
     let unknown_contributor_ip = IpAddr::V4("0.0.0.3".parse().unwrap());
 
     coordinator.initialize().unwrap();
-    let coordinator_keypair = KeyPair::custom_new(coordinator.environment().default_verifier_signing_key(), coordinator.environment().coordinator_verifiers()[0].address());
+    let coordinator_keypair = KeyPair::custom_new(
+        coordinator.environment().default_verifier_signing_key(),
+        coordinator.environment().coordinator_verifiers()[0].address(),
+    );
 
-    let coord_verifier = TestParticipant{
+    let coord_verifier = TestParticipant {
         _inner: coordinator.environment().coordinator_verifiers()[0].clone(),
         address: coordinator_ip,
         keypair: coordinator_keypair,
-        locked_locators: None
+        locked_locators: None,
     };
 
     coordinator
@@ -137,7 +140,7 @@ fn build_context() -> TestCtx {
         rocket,
         contributors: vec![test_participant1, test_participant2],
         unknown_participant,
-        coordinator: coord_verifier
+        coordinator: coord_verifier,
     }
 }
 
@@ -475,7 +478,11 @@ fn test_contribution() {
     let client = Client::tracked(ctx.rocket).expect("Invalid rocket instance");
 
     // Download chunk
-    let sig_req = SignedRequest::try_sign(&ctx.contributors[0].keypair, Some(ctx.contributors[0].locked_locators.clone().unwrap())).unwrap();
+    let sig_req = SignedRequest::try_sign(
+        &ctx.contributors[0].keypair,
+        Some(ctx.contributors[0].locked_locators.clone().unwrap()),
+    )
+    .unwrap();
     let mut req = client.get("/download/chunk").json(&sig_req);
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
@@ -483,9 +490,7 @@ fn test_contribution() {
     let task: Task = response.into_json().unwrap();
 
     // Get challenge
-    req = client
-        .get("/contributor/challenge")
-        .json(&sig_req);
+    req = client.get("/contributor/challenge").json(&sig_req);
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert!(response.body().is_some());


### PR DESCRIPTION
First implementation to address #10

- Adds signature to all the requests
- Makes the `update`, `verify` and `stop` endpoints accesible only by the coordinator iteself
- Stores the generated keypair in a file for signing of following requests (partially addresses issue #11)