### PR TITLE
Heartbeat fix

### DIFF
--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -202,10 +202,11 @@ async fn contribute(client: &Client, coordinator: &mut Url, keypair: &KeyPair, h
             }
             ContributorStatus::Round => {
                 do_contribute(client, coordinator, keypair).await.expect("Contribution failed");
-                // NOTE: need to manually cancel the heartbeat task becasue, by default, async runtimes use detach on drop strategy
-                //  (see here https://blog.yoshuawuyts.com/async-cancellation-1/#cancelling-tasks), meaning that the task
+                // NOTE: need to manually cancel the heartbeat task because, by default, async runtimes use detach on drop strategy
+                //  (see https://blog.yoshuawuyts.com/async-cancellation-1/#cancelling-tasks), meaning that the task
                 //  only gets detached from the main execution unit but keeps running in the background until the main
-                //  function returns
+                //  function returns. This would cause the contributor to send heartbeats even after it has been removed
+                //  from the list of current contributors, causing an error
                 heartbeat_handle.abort();
             }
             ContributorStatus::Finished => {

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// A private/public key couple encoded in [`base64`]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KeyPair {
     pubkey: String,
     sigkey: String,

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -28,7 +28,6 @@ async fn update_coordinator(coordinator: Arc<RwLock<Coordinator>>) -> Result<()>
         tokio::time::sleep(UPDATE_TIME).await;
 
         rest::perform_coordinator_update(coordinator.clone()).await?;
-        debug!("Coordinator updated");
     }
 }
 
@@ -38,7 +37,6 @@ async fn verify_contributions(coordinator: Arc<RwLock<Coordinator>>) -> Result<(
         tokio::time::sleep(UPDATE_TIME).await;
 
         rest::perform_verify_chunks(coordinator.clone()).await?;
-        debug!("Verified pending contributions");
     }
 }
 
@@ -119,7 +117,7 @@ pub async fn main() {
     // Spawn Rocket server task
     let rocket_handle = rocket::tokio::spawn(ignite_rocket.launch());
 
-    tokio::select! { //FIXME: handle this select?
+    tokio::select! {
         update_result = update_handle => {
             match update_result.expect("Update task panicked") {
                 Ok(()) => info!("Update task completed"),

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -20,23 +20,25 @@ use rocket::{
 use anyhow::Result;
 use std::sync::Arc;
 
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 /// Constantly updates the [`Coordinator`] periodically
 async fn update_coordinator(coordinator: Arc<RwLock<Coordinator>>) -> Result<()> {
     loop {
-        rest::perform_coordinator_update(coordinator.clone()).await?;
-
         tokio::time::sleep(UPDATE_TIME).await;
+
+        rest::perform_coordinator_update(coordinator.clone()).await?;
+        debug!("Coordinator updated");
     }
 }
 
 /// Constantly verifies the pending contributions
 async fn verify_contributions(coordinator: Arc<RwLock<Coordinator>>) -> Result<()> {
     loop {
-        rest::perform_verify_chunks(coordinator.clone()).await?;
-
         tokio::time::sleep(UPDATE_TIME).await;
+
+        rest::perform_verify_chunks(coordinator.clone()).await?;
+        debug!("Verified pending contributions");
     }
 }
 
@@ -117,7 +119,7 @@ pub async fn main() {
     // Spawn Rocket server task
     let rocket_handle = rocket::tokio::spawn(ignite_rocket.launch());
 
-    tokio::select! {
+    tokio::select! { //FIXME: handle this select?
         update_result = update_handle => {
             match update_result.expect("Update task panicked") {
                 Ok(()) => info!("Update task completed"),


### PR DESCRIPTION
Fixes #20.

Also improves the handling of the heartbeat signal, canceling the task once the contribution is over to prevent the contributor from sending a heartbeat even once it has been moved to the list of finished contributors