### PR TITLE
Signature improvement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ update:
 clean:
 	$(CARGO) clean --release
 
-.PHONY : build check clean clippy close-ceremony contribution fmt contributor run-coordinator test-coordinator test-e2e update
+.PHONY : build check clean clippy clippy-fix close-ceremony contribution fmt contribution run-coordinator test-coordinator test-e2e update verify

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::ops::Deref;
 
 /// A private/public key couple encoded in [`base64`]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KeyPair {
     pubkey: String,
     sigkey: String,

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use tracing::{error, info};
 
-/// Constantly updates the [`Coordinator`] periodically
+/// Periodically updates the [`Coordinator`]
 async fn update_coordinator(coordinator: Arc<RwLock<Coordinator>>) -> Result<()> {
     loop {
         rest::perform_coordinator_update(coordinator.clone()).await?;
@@ -31,7 +31,7 @@ async fn update_coordinator(coordinator: Arc<RwLock<Coordinator>>) -> Result<()>
     }
 }
 
-/// Constantly verifies the pending contributions
+/// Periodically verifies the pending contributions
 async fn verify_contributions(coordinator: Arc<RwLock<Coordinator>>) -> Result<()> {
     loop {
         rest::perform_verify_chunks(coordinator.clone()).await?;


### PR DESCRIPTION
Improve the signature of the requests as follows. Fixes #10 

In the current implementation, when a request carries a body, the body is the only element that gets signed.
This PR improves on this by signing the concatenation of the pubkey of the contributor and the body itself.