### PR TITLE
Artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ tmp_*
 
 **/*.env
 
-# Contribution artifacts FIXME:
-contributors.json
-contributors/
+# Contribution artifacts
 *.params
 namada_contributor_info_round_*

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,7 @@ tmp_*
 **/*.env
 
 # Contribution artifacts FIXME:
+contributors.json
+contributors/
 *.params
-*keypair
+namada_contributor_info_round_*

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,6 @@ tmp_*
 
 **/*.env
 
-# Contribution artifacts
+# Contribution artifacts FIXME:
 *.params
 *keypair

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,7 +253,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -265,6 +265,15 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -665,6 +674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "colored"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -844,7 +862,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -1978,7 +1996,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.11.2",
  "serde",
 ]
@@ -2132,7 +2150,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -2274,7 +2292,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2393,7 +2411,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-integer",
  "num-traits",
 ]
@@ -2404,7 +2422,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -2414,7 +2432,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -2536,7 +2554,7 @@ version = "0.9.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5fd19fb3e0a8191c1e34935718976a3e70c112ab9a24af6d7cadccd9d90bc0"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "pkg-config",
@@ -2814,6 +2832,7 @@ dependencies = [
  "phase1",
  "phase2 0.2.2",
  "rand 0.4.6",
+ "rand 0.6.5",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -3141,6 +3160,25 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc 0.1.0",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift 0.1.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -3149,7 +3187,7 @@ dependencies = [
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
- "rand_hc",
+ "rand_hc 0.2.0",
 ]
 
 [[package]]
@@ -3161,6 +3199,16 @@ dependencies = [
  "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3218,11 +3266,73 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3240,7 +3350,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -3916,7 +4026,7 @@ dependencies = [
  "phase1-cli",
  "phase1-coordinator",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "reqwest",
  "serde",
  "serde_json",
@@ -4105,7 +4215,7 @@ source = "git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c#fc997c3e99ecc42d3
 dependencies = [
  "derivative",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "rustc_version",
  "serde",
  "snarkvm-fields 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
@@ -4221,7 +4331,7 @@ dependencies = [
  "bincode",
  "derivative",
  "rand 0.8.5",
- "rand_xorshift",
+ "rand_xorshift 0.3.0",
  "serde",
  "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=fc997c)",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,10 +370,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bip39"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e89470017230c38e52b82b3ee3f530db1856ba1d434e3a67a3456a8a8dec5f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand_core 0.4.2",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce18265ec2324ad075345d5814fbeed4f41f0a660055dc78840b74d19b874b1"
 
 [[package]]
 name = "bitflags"
@@ -2743,7 +2759,9 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bip39",
  "bs58",
+ "chrono",
  "ed25519-compact",
  "fs-err",
  "gumdrop",
@@ -2752,6 +2770,7 @@ dependencies = [
  "phase1",
  "phase1-coordinator",
  "rand 0.8.5",
+ "regex",
  "reqwest",
  "rocket",
  "rustc_version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2759,7 +2759,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",
- "bip39",
  "bs58",
  "chrono",
  "ed25519-compact",
@@ -2793,6 +2792,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bellman 0.11.2",
+ "bip39",
  "blake2 0.10.4",
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls12_381",
@@ -2817,6 +2817,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
+ "regex",
  "rocket",
  "sapling-crypto",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ dependencies = [
  "blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls12_381",
  "byteorder",
+ "chrono",
  "ed25519-compact",
  "exitcode",
  "fs-err",

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ verify: # Verify pending contributions on local coordinator (127.0.0.1:8000)
 update-coordinator: # Update manually the coordinator
 	RUST_LOG=debug $(CARGO) run $(CLI_FLAGS) update-coordinator
 
+get-contributions: # Get the received contributions on local coordinator (127.0.0.1:8000)
+	RUST_LOG=debug $(CARGO) run $(CLI_FLAGS) get-contributions
+
 run-coordinator:
 	RUST_LOG=debug $(CARGO) run --bin phase1-coordinator
 
@@ -44,6 +47,4 @@ update:
 clean:
 	$(CARGO) clean --release
 
-# FIXME: add steps for the two new endpoints
-
-.PHONY : build check clean clippy clippy-fix close-ceremony contribution fmt contribution run-coordinator test-coordinator test-e2e update verify
+.PHONY : build check clean clippy clippy-fix close-ceremony contribution fmt get-contributions run-coordinator test-coordinator test-e2e update verify

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,6 @@ update:
 clean:
 	$(CARGO) clean --release
 
+# FIXME: add steps for the two new endpoints
+
 .PHONY : build check clean clippy clippy-fix close-ceremony contribution fmt contribution run-coordinator test-coordinator test-e2e update verify

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -16,9 +16,11 @@ serde = "1.0.136"
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = "1.0.57"
-ed25519-compact = "1.0.11"
+bip0039 = "0.10.1"
 bs58 = "0.4.0"
 base64 = "0.13.0"
+chrono = "0.4"
+ed25519-compact = "1.0.11"
 fs-err = "2.6"
 gumdrop = { version = "0.8.0" }
 hex = { version = "0.4.2" }

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -16,7 +16,6 @@ serde = "1.0.136"
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = "1.0.57"
-bip39 = { version = "1.0.1", default-features = false }
 bs58 = "0.4.0"
 base64 = "0.13.0"
 chrono = "0.4"

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -16,7 +16,7 @@ serde = "1.0.136"
 snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c" }
 
 anyhow = "1.0.57"
-bip0039 = "0.10.1"
+bip39 = { version = "1.0.1", default-features = false }
 bs58 = "0.4.0"
 base64 = "0.13.0"
 chrono = "0.4"

--- a/phase1-cli/Cargo.toml
+++ b/phase1-cli/Cargo.toml
@@ -26,6 +26,7 @@ gumdrop = { version = "0.8.0" }
 hex = { version = "0.4.2" }
 memmap = { version = "0.7.0" }
 rand = { version = "0.8" }
+regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0.81"
 structopt = "0.3"

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -330,10 +330,10 @@ async fn main() {
 
     match opt {
         CeremonyOpt::Contribute(mut url) => {
-            let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(false)})
-        .await
-        .unwrap()
-        .expect("Error while generating the keypair");
+            let keypair = tokio::task::spawn_blocking(|| io::generate_keypair(false))
+                .await
+                .unwrap()
+                .expect("Error while generating the keypair");
 
             let mut contrib_info = tokio::task::spawn_blocking(initialize_contribution)
                 .await
@@ -345,11 +345,11 @@ async fn main() {
             contribution_loop(&client, &mut url.coordinator, &keypair, contrib_info).await;
         }
         CeremonyOpt::CloseCeremony(mut url) => {
-            let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(true)})
-        .await
-        .unwrap()
-        .expect("Error while generating the keypair");
-    
+            let keypair = tokio::task::spawn_blocking(|| io::generate_keypair(true))
+                .await
+                .unwrap()
+                .expect("Error while generating the keypair");
+
             close_ceremony(&client, &mut url.coordinator, &keypair).await;
         }
         CeremonyOpt::GetContributions(mut url) => {
@@ -357,20 +357,20 @@ async fn main() {
         }
         #[cfg(debug_assertions)]
         CeremonyOpt::VerifyContributions(mut url) => {
-            let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(true)})
-        .await
-        .unwrap()
-        .expect("Error while generating the keypair");
-    
+            let keypair = tokio::task::spawn_blocking(|| io::generate_keypair(true))
+                .await
+                .unwrap()
+                .expect("Error while generating the keypair");
+
             verify_contributions(&client, &mut url.coordinator, &keypair).await;
         }
         #[cfg(debug_assertions)]
         CeremonyOpt::UpdateCoordinator(mut url) => {
-            let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(true)})
-        .await
-        .unwrap()
-        .expect("Error while generating the keypair");
-    
+            let keypair = tokio::task::spawn_blocking(|| io::generate_keypair(true))
+                .await
+                .unwrap()
+                .expect("Error while generating the keypair");
+
             update_coordinator(&client, &mut url.coordinator, &keypair).await;
         }
     }

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -189,11 +189,7 @@ async fn contribute(client: &Client, coordinator: &mut Url, keypair: &KeyPair, m
     contrib_info.timestamps.end_contribution = Utc::now();
 
     // Compute signature of contributor info
-    let mut serde_contrib_info = serde_json::to_value(contrib_info.clone())?;
-    serde_contrib_info["contributor_info_signature"].take();
-    let serialized_contrib_info = serde_contrib_info.to_string();
-    let contrib_info_signature = Production.sign(keypair.sigkey(), serialized_contrib_info.as_str())?;
-    contrib_info.contributor_info_signature = contrib_info_signature;
+    contrib_info.try_sign(keypair.sigkey()).expect("Error while signing the contribution info");
 
     // Write contribution info file and send it to the Coordinator
     async_fs::write(format!("namada_contributor_info_round_{}.json", contrib_info.ceremony_round), &serde_json::to_vec(&contrib_info)?).await?;

--- a/phase1-cli/src/bin/phase1.rs
+++ b/phase1-cli/src/bin/phase1.rs
@@ -189,7 +189,7 @@ async fn contribute(client: &Client, coordinator: &mut Url, keypair: &KeyPair, m
     contrib_info.timestamps.end_contribution = Utc::now();
 
     // Compute signature of contributor info
-    contrib_info.try_sign(keypair.sigkey()).expect("Error while signing the contribution info");
+    contrib_info.try_sign(keypair).expect("Error while signing the contribution info");
 
     // Write contribution info file and send it to the Coordinator
     async_fs::write(format!("namada_contributor_info_round_{}.json", contrib_info.ceremony_round), &serde_json::to_vec(&contrib_info)?).await?;
@@ -322,5 +322,3 @@ async fn main() {
         }
     }
 }
-
-// FIXME: fix unused imports

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -33,15 +33,15 @@ pub struct CoordinatorUrl {
         help = "The ip address and port of the coordinator",
         required = true,
         default_value = "http://127.0.0.1:8000",
-        env = "ANOMA_COORDINATOR_ADDRESS",
+        env = "NAMADA_COORDINATOR_ADDRESS",
         parse(try_from_str)
     )]
     pub coordinator: Url,
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "anoma-mpc", about = "Anoma CLI for trusted setup.")]
-pub enum ContributorOpt {
+#[structopt(name = "namada-mpc", about = "Namada CLI for trusted setup.")]
+pub enum CeremonyOpt {
     #[structopt(about = "Contribute to the ceremony")]
     Contribute(CoordinatorUrl),
     #[structopt(about = "Stop the coordinator and close the ceremony")]

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -27,6 +27,7 @@ use phase1_coordinator::{
 use reqwest::Url;
 use structopt::StructOpt;
 
+
 #[derive(Debug, StructOpt)]
 pub struct CoordinatorUrl {
     #[structopt(
@@ -40,10 +41,29 @@ pub struct CoordinatorUrl {
 }
 
 #[derive(Debug, StructOpt)]
+pub struct ContributionArgs {
+    #[structopt(flatten)]
+    pub coordinator: CoordinatorUrl,
+    #[structopt(
+        help = "The path to the mnemonic phrase file needed to generate the keypair for the contribution. The phrase should consists of 24 words.",
+        required = true,
+    )]
+    pub mnemonic_file_path: Path,
+    #[structopt(
+        help = "The passhprase used to generate the seed from the mnemonic.",
+        required = true,
+    )]
+    pub passphrase: String
+}
+
+// FIXME: since also for the coordinator we must use mnemonics now, the coordinator will pass the mnemonic file (possibly encrypted), so no need to save it, but all the commands
+//  of the coordinator will need to take the path to this file + passphrase + encyption key?
+
+#[derive(Debug, StructOpt)]
 #[structopt(name = "anoma-mpc", about = "Anoma CLI for trusted setup.")]
 pub enum ContributorOpt {
-    #[structopt(about = "Contribute to the trusted setup")]
-    Contribute(CoordinatorUrl),
+    #[structopt(about = "Contribute to the ceremony")]
+    Contribute(ContributionArgs),
     #[structopt(about = "Stop the coordinator and close the ceremony")]
     CloseCeremony(CoordinatorUrl),
     #[cfg(debug_assertions)]

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -46,6 +46,8 @@ pub enum ContributorOpt {
     Contribute(CoordinatorUrl),
     #[structopt(about = "Stop the coordinator and close the ceremony")]
     CloseCeremony(CoordinatorUrl),
+    #[structopt(about = "Get a list of all the contributions received")]
+    GetContributions(CoordinatorUrl),
     #[cfg(debug_assertions)]
     #[structopt(about = "Verify the pending contributions")]
     VerifyContributions(CoordinatorUrl),

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -27,7 +27,6 @@ use phase1_coordinator::{
 use reqwest::Url;
 use structopt::StructOpt;
 
-
 #[derive(Debug, StructOpt)]
 pub struct CoordinatorUrl {
     #[structopt(
@@ -41,24 +40,10 @@ pub struct CoordinatorUrl {
 }
 
 #[derive(Debug, StructOpt)]
-pub struct ContributionArgs {
-    #[structopt(flatten)]
-    pub coordinator: CoordinatorUrl,
-    #[structopt(
-        help = "The mnemonic phrase needed to generate the keypair for the contribution. The phrase should consists of 24 words.",
-        required = true,
-    )]
-    pub mnemonic: String,
-}
-
-// FIXME: since also for the coordinator we must use mnemonics now, the coordinator will pass the mnemonic, so no need to save it, but all the commands
-//  of the coordinator will need to take the path to this file + passphrase + encyption key?
-
-#[derive(Debug, StructOpt)]
 #[structopt(name = "anoma-mpc", about = "Anoma CLI for trusted setup.")]
 pub enum ContributorOpt {
     #[structopt(about = "Contribute to the ceremony")]
-    Contribute(ContributionArgs),
+    Contribute(CoordinatorUrl),
     #[structopt(about = "Stop the coordinator and close the ceremony")]
     CloseCeremony(CoordinatorUrl),
     #[cfg(debug_assertions)]

--- a/phase1-cli/src/lib.rs
+++ b/phase1-cli/src/lib.rs
@@ -45,18 +45,13 @@ pub struct ContributionArgs {
     #[structopt(flatten)]
     pub coordinator: CoordinatorUrl,
     #[structopt(
-        help = "The path to the mnemonic phrase file needed to generate the keypair for the contribution. The phrase should consists of 24 words.",
+        help = "The mnemonic phrase needed to generate the keypair for the contribution. The phrase should consists of 24 words.",
         required = true,
     )]
-    pub mnemonic_file_path: Path,
-    #[structopt(
-        help = "The passhprase used to generate the seed from the mnemonic.",
-        required = true,
-    )]
-    pub passphrase: String
+    pub mnemonic: String,
 }
 
-// FIXME: since also for the coordinator we must use mnemonics now, the coordinator will pass the mnemonic file (possibly encrypted), so no need to save it, but all the commands
+// FIXME: since also for the coordinator we must use mnemonics now, the coordinator will pass the mnemonic, so no need to save it, but all the commands
 //  of the coordinator will need to take the path to this file + passphrase + encyption key?
 
 #[derive(Debug, StructOpt)]

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -267,17 +267,14 @@ pub async fn post_contribution_info(
 pub async fn get_contributions_info(
     client: &Client,
     coordinator_address: &mut Url,
-    keypair: &KeyPair,
 ) -> Result<Vec<TrimmedContributionInfo>> {
-    let response = submit_request::<()>(
-        client,
-        coordinator_address,
-        "/contribution_info",
-        keypair,
-        None,
-        &Method::GET,
-    )
-    .await?;
+    coordinator_address.set_path("/contribution_info");
+    let req = client.get(coordinator_address.to_owned());
+    let response = req.send().await?;
 
-    Ok(response.json::<Vec<TrimmedContributionInfo>>().await?)
+    if response.status().is_success() {
+        Ok(response.json::<Vec<TrimmedContributionInfo>>().await?)
+    } else {
+        Err(RequestError::Server(response.text().await?))
+    }
 }

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -1,6 +1,6 @@
 //! Requests sent to the [Coordinator](`phase1-coordinator::Coordinator`) server.
 
-use phase1_coordinator::{authentication::KeyPair, rest::{ContributionInfo, SignedRequest, TrimmedContributionInfo}};
+use phase1_coordinator::{authentication::KeyPair, objects::{ContributionInfo, TrimmedContributionInfo}, rest::SignedRequest};
 use reqwest::{Client, Method, Response, Url};
 use serde::Serialize;
 use std::collections::LinkedList;

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -1,6 +1,6 @@
 //! Requests sent to the [Coordinator](`phase1-coordinator::Coordinator`) server.
 
-use phase1_coordinator::{authentication::KeyPair, rest::SignedRequest};
+use phase1_coordinator::{authentication::KeyPair, rest::{ContributionInfo, SignedRequest, TrimmedContributionInfo}};
 use reqwest::{Client, Method, Response, Url};
 use serde::Serialize;
 use std::collections::LinkedList;
@@ -237,4 +237,18 @@ pub async fn get_contributor_queue_status(
     .await?;
 
     Ok(response.json::<ContributorStatus>().await?)
+}
+
+/// Send [`ContributionInfo`] to the Coordinator.
+pub async fn post_contribution_info(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair, request_body: ContributionInfo) -> Result<()> {
+    submit_request::<ContributionInfo>(client, coordinator_address, "/contributor/contribution_info", keypair, Some(request_body), &Method::POST).await?;
+
+    Ok(())
+}
+
+/// Retrieve the list of contributions
+pub async fn get_contributions_info(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<Vec<TrimmedContributionInfo>> {
+    let response = submit_request::<()>(client, coordinator_address, "/contribution_info", keypair, None, &Method::GET).await?;
+
+    Ok(response.json::<Vec<TrimmedContributionInfo>>().await?)
 }

--- a/phase1-cli/src/requests.rs
+++ b/phase1-cli/src/requests.rs
@@ -1,6 +1,10 @@
 //! Requests sent to the [Coordinator](`phase1-coordinator::Coordinator`) server.
 
-use phase1_coordinator::{authentication::KeyPair, objects::{ContributionInfo, TrimmedContributionInfo}, rest::SignedRequest};
+use phase1_coordinator::{
+    authentication::KeyPair,
+    objects::{ContributionInfo, TrimmedContributionInfo},
+    rest::SignedRequest,
+};
 use reqwest::{Client, Method, Response, Url};
 use serde::Serialize;
 use std::collections::LinkedList;
@@ -240,15 +244,40 @@ pub async fn get_contributor_queue_status(
 }
 
 /// Send [`ContributionInfo`] to the Coordinator.
-pub async fn post_contribution_info(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair, request_body: ContributionInfo) -> Result<()> {
-    submit_request::<ContributionInfo>(client, coordinator_address, "/contributor/contribution_info", keypair, Some(request_body), &Method::POST).await?;
+pub async fn post_contribution_info(
+    client: &Client,
+    coordinator_address: &mut Url,
+    keypair: &KeyPair,
+    request_body: ContributionInfo,
+) -> Result<()> {
+    submit_request::<ContributionInfo>(
+        client,
+        coordinator_address,
+        "/contributor/contribution_info",
+        keypair,
+        Some(request_body),
+        &Method::POST,
+    )
+    .await?;
 
     Ok(())
 }
 
 /// Retrieve the list of contributions
-pub async fn get_contributions_info(client: &Client, coordinator_address: &mut Url, keypair: &KeyPair) -> Result<Vec<TrimmedContributionInfo>> {
-    let response = submit_request::<()>(client, coordinator_address, "/contribution_info", keypair, None, &Method::GET).await?;
+pub async fn get_contributions_info(
+    client: &Client,
+    coordinator_address: &mut Url,
+    keypair: &KeyPair,
+) -> Result<Vec<TrimmedContributionInfo>> {
+    let response = submit_request::<()>(
+        client,
+        coordinator_address,
+        "/contribution_info",
+        keypair,
+        None,
+        &Method::GET,
+    )
+    .await?;
 
     Ok(response.json::<Vec<TrimmedContributionInfo>>().await?)
 }

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -116,7 +116,9 @@ async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) 
             rest::get_tasks_left,
             rest::stop_coordinator,
             rest::verify_chunks,
-            rest::get_contributor_queue_status
+            rest::get_contributor_queue_status,
+            rest::post_contribution_info,
+            rest::get_contributions_info
         ])
         .manage(coordinator);
 

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -9,8 +9,8 @@ use std::{io::Write, net::IpAddr, sync::Arc};
 use phase1_coordinator::{
     authentication::{KeyPair, Production, Signature},
     commands::Computation,
-    environment::{Parameters, Testing},
-    objects::{LockedLocators, Task},
+    environment::Testing,
+    objects::{ContributionInfo, LockedLocators, Task},
     rest::{self, PostChunkRequest},
     storage::{ContributionLocator, ContributionSignatureLocator, Object},
     testing::coordinator,
@@ -310,7 +310,6 @@ async fn test_wrong_contribute_chunk() {
 
     // Non-existing contributor key
     let mut url = Url::parse(COORDINATOR_ADDRESS).unwrap();
-
     let response = requests::post_contribute_chunk(&client, &mut url, &ctx.unknown_participant.keypair, 0).await;
     assert!(response.is_err());
 
@@ -318,13 +317,55 @@ async fn test_wrong_contribute_chunk() {
     handle.abort()
 }
 
-/// To test a full contribution we need to test the 5 involved endpoints sequentially:
+#[tokio::test]
+async fn test_wrong_post_contribution_info() {
+    let client = Client::new();
+    // Spawn the server and get the test context
+    let (ctx, handle) = test_prelude().await;
+    // Wait for server startup
+    time::sleep(Duration::from_millis(1000)).await;
+
+    let contrib_info = ContributionInfo::default();
+
+    // Non-existing contributor key
+    let mut url = Url::parse(COORDINATOR_ADDRESS).unwrap();
+    let response = requests::post_contribution_info(&client, &mut url, &ctx.unknown_participant.keypair, contrib_info.clone()).await;
+    assert!(response.is_err());
+
+    // Non-current-contributor participant
+    let response = requests::post_contribution_info(&client, &mut url, &ctx.contributors[1].keypair, contrib_info).await;
+    assert!(response.is_err());
+
+    // Drop the server
+    handle.abort()
+}
+
+#[tokio::test]
+async fn test_wrong_get_contributions_info() {
+    let client = Client::new();
+    // Spawn the server and get the test context
+    let (ctx, handle) = test_prelude().await;
+    // Wait for server startup
+    time::sleep(Duration::from_millis(1000)).await;
+
+    // Wrong, request from non-coordinator participant
+    let mut url = Url::parse(COORDINATOR_ADDRESS).unwrap();
+    let response = requests::get_contributions_info(&client, &mut url, &ctx.contributors[0].keypair).await;
+    assert!(response.is_err());
+
+    // Drop the server
+    handle.abort()
+}
+
+/// To test a full contribution we need to test the 7 involved endpoints sequentially:
 ///
 /// - get_chunk
 /// - get_challenge
 /// - post_contribution_chunk
 /// - contribute_chunk
 /// - verify_chunk
+/// - post_contributor_info
+/// - get_contributions_info
 ///
 #[tokio::test]
 async fn test_contribution() {
@@ -405,6 +446,24 @@ async fn test_contribution() {
     requests::get_verify_chunks(&client, &mut url, &ctx.coordinator.keypair)
         .await
         .unwrap();
+
+    // Post contribution info
+    let mut contrib_info = ContributionInfo::default();
+    contrib_info.full_name = Some(String::from("Test Name"));
+    contrib_info.email = Some(String::from("test@mail.dev"));
+    contrib_info.public_key = ctx.contributors[0].keypair.pubkey().to_owned();
+    contrib_info.ceremony_round = ctx.contributors[0].locked_locators.as_ref().unwrap().current_contribution().round_height();
+    contrib_info.try_sign(&ctx.contributors[0].keypair).unwrap();
+
+    requests::post_contribution_info(&client, &mut url, &ctx.contributors[0].keypair, contrib_info).await.unwrap();
+
+    // Get contributions info
+    let summary = requests::get_contributions_info(&client, &mut url, &ctx.coordinator.keypair).await.unwrap();
+    assert_eq!(summary.len(), 1);
+    assert_eq!(summary[0].public_key(), ctx.contributors[0].keypair.pubkey());
+    assert!(!summary[0].is_another_machine());
+    assert!(!summary[0].is_own_seed_of_randomness());
+    assert_eq!(summary[0].ceremony_round(), 1);
 
     // Drop the server
     handle.abort()

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -329,11 +329,18 @@ async fn test_wrong_post_contribution_info() {
 
     // Non-existing contributor key
     let mut url = Url::parse(COORDINATOR_ADDRESS).unwrap();
-    let response = requests::post_contribution_info(&client, &mut url, &ctx.unknown_participant.keypair, contrib_info.clone()).await;
+    let response = requests::post_contribution_info(
+        &client,
+        &mut url,
+        &ctx.unknown_participant.keypair,
+        contrib_info.clone(),
+    )
+    .await;
     assert!(response.is_err());
 
     // Non-current-contributor participant
-    let response = requests::post_contribution_info(&client, &mut url, &ctx.contributors[1].keypair, contrib_info).await;
+    let response =
+        requests::post_contribution_info(&client, &mut url, &ctx.contributors[1].keypair, contrib_info).await;
     assert!(response.is_err());
 
     // Drop the server
@@ -452,13 +459,22 @@ async fn test_contribution() {
     contrib_info.full_name = Some(String::from("Test Name"));
     contrib_info.email = Some(String::from("test@mail.dev"));
     contrib_info.public_key = ctx.contributors[0].keypair.pubkey().to_owned();
-    contrib_info.ceremony_round = ctx.contributors[0].locked_locators.as_ref().unwrap().current_contribution().round_height();
+    contrib_info.ceremony_round = ctx.contributors[0]
+        .locked_locators
+        .as_ref()
+        .unwrap()
+        .current_contribution()
+        .round_height();
     contrib_info.try_sign(&ctx.contributors[0].keypair).unwrap();
 
-    requests::post_contribution_info(&client, &mut url, &ctx.contributors[0].keypair, contrib_info).await.unwrap();
+    requests::post_contribution_info(&client, &mut url, &ctx.contributors[0].keypair, contrib_info)
+        .await
+        .unwrap();
 
     // Get contributions info
-    let summary = requests::get_contributions_info(&client, &mut url, &ctx.coordinator.keypair).await.unwrap();
+    let summary = requests::get_contributions_info(&client, &mut url, &ctx.coordinator.keypair)
+        .await
+        .unwrap();
     assert_eq!(summary.len(), 1);
     assert_eq!(summary[0].public_key(), ctx.contributors[0].keypair.pubkey());
     assert!(!summary[0].is_another_machine());

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -53,14 +53,8 @@ struct TestCtx {
 
 /// Launch the rocket server for testing with the proper configuration as a separate async Task.
 async fn test_prelude() -> (TestCtx, JoinHandle<Result<Rocket<Ignite>, Error>>) {
-    let parameters = Parameters::TestAnoma {
-        number_of_chunks: 1,
-        power: 6,
-        batch_size: 16,
-    };
-
     // Reset storage to prevent state conflicts between tests and initialize test environment
-    let environment = coordinator::initialize_test_environment(&Testing::from(parameters).into());
+    let environment = coordinator::initialize_test_environment(&Testing::default().into());
 
     // Instantiate the coordinator
     let mut coordinator = Coordinator::new(environment, Arc::new(Production)).unwrap();

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -347,23 +347,6 @@ async fn test_wrong_post_contribution_info() {
     handle.abort()
 }
 
-#[tokio::test]
-async fn test_wrong_get_contributions_info() {
-    let client = Client::new();
-    // Spawn the server and get the test context
-    let (ctx, handle) = test_prelude().await;
-    // Wait for server startup
-    time::sleep(Duration::from_millis(1000)).await;
-
-    // Wrong, request from non-coordinator participant
-    let mut url = Url::parse(COORDINATOR_ADDRESS).unwrap();
-    let response = requests::get_contributions_info(&client, &mut url, &ctx.contributors[0].keypair).await;
-    assert!(response.is_err());
-
-    // Drop the server
-    handle.abort()
-}
-
 /// To test a full contribution we need to test the 7 involved endpoints sequentially:
 ///
 /// - get_chunk
@@ -472,7 +455,7 @@ async fn test_contribution() {
         .unwrap();
 
     // Get contributions info
-    let summary = requests::get_contributions_info(&client, &mut url, &ctx.coordinator.keypair)
+    let summary = requests::get_contributions_info(&client, &mut url)
         .await
         .unwrap();
     assert_eq!(summary.len(), 1);

--- a/phase1-cli/tests/e2e.rs
+++ b/phase1-cli/tests/e2e.rs
@@ -455,9 +455,7 @@ async fn test_contribution() {
         .unwrap();
 
     // Get contributions info
-    let summary = requests::get_contributions_info(&client, &mut url)
-        .await
-        .unwrap();
+    let summary = requests::get_contributions_info(&client, &mut url).await.unwrap();
     assert_eq!(summary.len(), 1);
     assert_eq!(summary[0].public_key(), ctx.contributors[0].keypair.pubkey());
     assert!(!summary[0].is_another_machine());

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -20,6 +20,7 @@ snarkvm-curves = {git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"}
 
 anyhow = { version = "1.0.37" }
 base64 = "0.13.0"
+chrono = "0.4"
 ed25519-compact = "1.0.11"
 fs-err = { version = "2.6.0" }
 futures = { version = "0.3" }

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -58,6 +58,7 @@ getrandom = {version = "0.2.6", features = ["js"]}
 hex = "0.4.2"
 itertools = "0.10.3"
 rand = {version = "0.8.5", default-features = false, features = ["getrandom"]}
+rand-06 = { package = "rand", version = "0.6" } # Used just for compatibility with bip39
 rand_chacha = "0.3.1"
 sha2 = "0.10.2"
 bls12_381 = "0.6.1"

--- a/phase1-coordinator/Cargo.toml
+++ b/phase1-coordinator/Cargo.toml
@@ -20,6 +20,7 @@ snarkvm-curves = {git = "https://github.com/AleoHQ/snarkVM.git", rev = "fc997c"}
 
 anyhow = { version = "1.0.37" }
 base64 = "0.13.0"
+bip39 = { version = "1.0.1", default-features = false }
 chrono = "0.4"
 ed25519-compact = "1.0.11"
 fs-err = { version = "2.6.0" }
@@ -27,6 +28,7 @@ futures = { version = "0.3" }
 memmap = { version = "0.7.0" }
 once_cell = { version = "1.5.2" }
 rayon = { version = "1.4.1" }
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde-aux = { version = "3.0" }
 serde-diff = { version = "0.4" }

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -1,6 +1,6 @@
 use crate::authentication::Signature as SigTrait;
 use base64;
-use ed25519_compact::{KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Signature};
+use ed25519_compact::{Error, KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Signature};
 use hex;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -13,14 +13,14 @@ pub struct KeyPair {
 }
 
 impl KeyPair {
-    /// Generate a random key pair.
-    pub fn new() -> Self {
-        let keypair = EdKeyPair::generate();
+    /// Generate a keypair from a seed
+    pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
+        let keypair = EdKeyPair::from_slice(seed)?;
 
-        KeyPair {
+        Ok(KeyPair {
             pubkey: base64::encode(keypair.pk.deref()),
             sigkey: base64::encode(keypair.sk.deref()),
-        }
+        })
     }
 
     /// Custom keypair available only in test

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -18,7 +18,7 @@ impl KeyPair {
         let seed = Seed::from_slice(&seed[0..32])?;
         let keypair = EdKeyPair::from_seed(seed);
 
-        Ok(KeyPair {
+        Ok(KeyPair { //FIXME: encode with Borsh and fix all the base64 and base58 encodings around
             pubkey: base64::encode(keypair.pk.deref()),
             sigkey: base64::encode(keypair.sk.deref()),
         })

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -24,8 +24,7 @@ impl KeyPair {
         })
     }
 
-    /// Generate a random key pair, only for tests.
-    #[cfg(debug_assertions)]
+    /// Generate a random keypair
     pub fn new() -> Self {
         let keypair = EdKeyPair::generate();
 

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -14,7 +14,7 @@ pub struct KeyPair {
 
 impl KeyPair {
     /// Generate a keypair from a seed
-    pub fn from_seed(seed: &[u8]) -> Result<Self, Error> {
+    pub fn try_from_seed(seed: &[u8]) -> Result<Self, Error> {
         let keypair = EdKeyPair::from_slice(seed)?;
 
         Ok(KeyPair {

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -18,7 +18,8 @@ impl KeyPair {
         let seed = Seed::from_slice(&seed[0..32])?;
         let keypair = EdKeyPair::from_seed(seed);
 
-        Ok(KeyPair { //FIXME: encode with Borsh and fix all the base64 and base58 encodings around
+        Ok(KeyPair {
+            //FIXME: encode with Borsh and fix all the base64 and base58 encodings around
             pubkey: base64::encode(keypair.pk.deref()),
             sigkey: base64::encode(keypair.sk.deref()),
         })

--- a/phase1-coordinator/src/authentication/production.rs
+++ b/phase1-coordinator/src/authentication/production.rs
@@ -1,6 +1,6 @@
 use crate::authentication::Signature as SigTrait;
 use base64;
-use ed25519_compact::{Error, KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Signature};
+use ed25519_compact::{Error, KeyPair as EdKeyPair, Noise, PublicKey, SecretKey, Seed, Signature};
 use hex;
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -15,12 +15,24 @@ pub struct KeyPair {
 impl KeyPair {
     /// Generate a keypair from a seed
     pub fn try_from_seed(seed: &[u8]) -> Result<Self, Error> {
-        let keypair = EdKeyPair::from_slice(seed)?;
+        let seed = Seed::from_slice(&seed[0..32])?;
+        let keypair = EdKeyPair::from_seed(seed);
 
         Ok(KeyPair {
             pubkey: base64::encode(keypair.pk.deref()),
             sigkey: base64::encode(keypair.sk.deref()),
         })
+    }
+
+    /// Generate a random key pair, only for tests.
+    #[cfg(debug_assertions)]
+    pub fn new() -> Self {
+        let keypair = EdKeyPair::generate();
+
+        KeyPair {
+            pubkey: base64::encode(keypair.pk.deref()),
+            sigkey: base64::encode(keypair.sk.deref()),
+        }
     }
 
     /// Custom keypair available only in test

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -6,14 +6,35 @@ use crate::{
     authentication::Signature,
     commands::{Aggregation, Initialization},
     coordinator_state::{
-        CeremonyStorageAction, CoordinatorState, DropParticipant, ParticipantInfo, ResetCurrentRoundStorageAction,
+        CeremonyStorageAction,
+        CoordinatorState,
+        DropParticipant,
+        ParticipantInfo,
+        ResetCurrentRoundStorageAction,
         RoundMetrics,
     },
     environment::{Deployment, Environment},
-    objects::{participant::*, task::TaskInitializationError, ContributionFileSignature, ContributionInfo, LockedLocators, Round, Task, TrimmedContributionInfo},
+    objects::{
+        participant::*,
+        task::TaskInitializationError,
+        ContributionFileSignature,
+        ContributionInfo,
+        LockedLocators,
+        Round,
+        Task,
+        TrimmedContributionInfo,
+    },
     storage::{
-        ContributionLocator, ContributionSignatureLocator, Disk, Locator, LocatorPath, Object, StorageAction,
-        StorageLocator, StorageObject, UpdateAction,
+        ContributionLocator,
+        ContributionSignatureLocator,
+        Disk,
+        Locator,
+        LocatorPath,
+        Object,
+        StorageAction,
+        StorageLocator,
+        StorageObject,
+        UpdateAction,
     },
 };
 use setup_utils::calculate_hash;
@@ -1629,20 +1650,32 @@ impl Coordinator {
     }
 
     /// Writes the contribution metadata to storage at the appropriate locator.
-    pub(crate) fn write_contribution_info(&mut self, contribution_info: ContributionInfo) -> Result<(), CoordinatorError> {
+    pub(crate) fn write_contribution_info(
+        &mut self,
+        contribution_info: ContributionInfo,
+    ) -> Result<(), CoordinatorError> {
         let round_height = Self::load_current_round_height(&self.storage)?;
-        self.storage.insert(Locator::ContributionInfoFile { round_height  }, Object::ContributionInfoFile(contribution_info))
+        self.storage.insert(
+            Locator::ContributionInfoFile { round_height },
+            Object::ContributionInfoFile(contribution_info),
+        )
     }
 
-    /// Appends current round summary to storage at the appropriate locator. 
-    pub(crate) fn update_contribution_summary(&mut self, contribution_summary: TrimmedContributionInfo) -> Result<(), CoordinatorError> {
+    /// Appends current round summary to storage at the appropriate locator.
+    pub(crate) fn update_contribution_summary(
+        &mut self,
+        contribution_summary: TrimmedContributionInfo,
+    ) -> Result<(), CoordinatorError> {
         let mut summary = match self.storage.get(&Locator::ContributionsInfoSummary)? {
             Object::ContributionsInfoSummary(summary) => summary,
             _ => unreachable!(),
         };
         summary.push(contribution_summary);
 
-        self.storage.update(&Locator::ContributionsInfoSummary, Object::ContributionsInfoSummary(summary))
+        self.storage.update(
+            &Locator::ContributionsInfoSummary,
+            Object::ContributionsInfoSummary(summary),
+        )
     }
 
     /// Writes the bytes of a contribution file signature to storage at the appropriate  
@@ -2460,14 +2493,11 @@ impl Coordinator {
 
     /// Verify a contribution using the coordinator's default verifier.
     /// This is just an interface to [`verify`]
-    /// 
+    ///
     /// #Error
     /// This function assumes that the given task has been indeed assigned to the
     /// default verifier.
-    pub fn default_verify(
-        &mut self,
-        task: &Task,
-    ) -> anyhow::Result<()> {
+    pub fn default_verify(&mut self, task: &Task) -> anyhow::Result<()> {
         let verifier = self.environment.coordinator_verifiers()[0].clone();
         let sigkey = self.environment.default_verifier_signing_key();
 
@@ -3015,16 +3045,18 @@ mod tests {
             // Run the computation
             let mut seed: Seed = [0; SEED_LENGTH];
             rand::thread_rng().fill_bytes(&mut seed[..]);
-            assert!(coordinator
-                .run_computation(
-                    round_height,
-                    chunk_id,
-                    contribution_id,
-                    &contributor,
-                    &contributor_signing_key,
-                    &seed
-                )
-                .is_ok());
+            assert!(
+                coordinator
+                    .run_computation(
+                        round_height,
+                        chunk_id,
+                        contribution_id,
+                        &contributor,
+                        &contributor_signing_key,
+                        &seed
+                    )
+                    .is_ok()
+            );
         }
 
         // Add contribution for round 1 chunk 0 contribution 1.
@@ -3069,16 +3101,18 @@ mod tests {
             // Run computation on round 1 chunk 0 contribution 1.
             let mut seed: Seed = [0; SEED_LENGTH];
             rand::thread_rng().fill_bytes(&mut seed[..]);
-            assert!(coordinator
-                .run_computation(
-                    round_height,
-                    chunk_id,
-                    contribution_id,
-                    contributor,
-                    &contributor_signing_key,
-                    &seed
-                )
-                .is_ok());
+            assert!(
+                coordinator
+                    .run_computation(
+                        round_height,
+                        chunk_id,
+                        contribution_id,
+                        contributor,
+                        &contributor_signing_key,
+                        &seed
+                    )
+                    .is_ok()
+            );
 
             // Add round 1 chunk 0 contribution 1.
             assert!(coordinator.add_contribution(chunk_id, &contributor).is_ok());
@@ -3376,11 +3410,13 @@ mod tests {
         let mut seeds = HashMap::new();
         for chunk_id in 0..TEST_ENVIRONMENT_3.number_of_chunks() {
             // Ensure contribution ID 0 is already verified by the coordinator.
-            assert!(coordinator
-                .current_round()?
-                .chunk(chunk_id)?
-                .get_contribution(0)?
-                .is_verified());
+            assert!(
+                coordinator
+                    .current_round()?
+                    .chunk(chunk_id)?
+                    .get_contribution(0)?
+                    .is_verified()
+            );
 
             // As contribution ID 0 is initialized by the coordinator, iterate from
             // contribution ID 1 up to the expected number of contributions.

--- a/phase1-coordinator/src/coordinator.rs
+++ b/phase1-coordinator/src/coordinator.rs
@@ -1613,7 +1613,6 @@ impl Coordinator {
 
     /// Writes the bytes of a contribution to storage at the appropriate file
     /// locator.
-    #[inline]
     pub(crate) fn write_contribution<T>(
         &mut self,
         contribution_locator: ContributionLocator,
@@ -1622,6 +1621,7 @@ impl Coordinator {
     where
         T: Into<Vec<u8>>,
     {
+        // Can use update instead of insert because the path is already initialized by other functions
         self.storage.update(
             &Locator::ContributionFile(contribution_locator),
             Object::ContributionFile(contribution.into()),
@@ -1629,18 +1629,16 @@ impl Coordinator {
     }
 
     /// Writes the contribution metadata to storage at the appropriate locator.
-    #[inline]
     pub(crate) fn write_contribution_info(&mut self, contribution_info: ContributionInfo) -> Result<(), CoordinatorError> {
         let round_height = Self::load_current_round_height(&self.storage)?;
-        self.storage.update(&Locator::ContributionInfoFile { round_height  }, Object::ContributionInfoFile(contribution_info))
+        self.storage.insert(Locator::ContributionInfoFile { round_height  }, Object::ContributionInfoFile(contribution_info))
     }
 
     /// Appends current round summary to storage at the appropriate locator. 
-    #[inline]
     pub(crate) fn update_contribution_summary(&mut self, contribution_summary: TrimmedContributionInfo) -> Result<(), CoordinatorError> {
         let mut summary = match self.storage.get(&Locator::ContributionsInfoSummary)? {
             Object::ContributionsInfoSummary(summary) => summary,
-            _ => unreachable!(), //FIXME: correct?
+            _ => unreachable!(),
         };
         summary.push(contribution_summary);
 
@@ -1649,7 +1647,6 @@ impl Coordinator {
 
     /// Writes the bytes of a contribution file signature to storage at the appropriate  
     /// locator.
-    #[inline]
     pub(crate) fn write_contribution_file_signature(
         &mut self,
         locator: ContributionSignatureLocator,
@@ -2314,7 +2311,6 @@ impl Coordinator {
     /// Returns a reference to the instantiation of `Storage` that this
     /// coordinator is using.
     ///
-    #[cfg(any(test, testing))]
     #[inline]
     pub(super) fn storage(&self) -> &Disk {
         &self.storage

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -571,7 +571,12 @@ impl Testing {
     fn generate_namada_env(keypair: &KeyPair) -> Self {
         Self {
             environment: Environment {
-                parameters: Parameters::Namada { number_of_chunks: 1, power: 6, batch_size: 16 }.to_settings(),
+                parameters: Parameters::Namada {
+                    number_of_chunks: 1,
+                    power: 6,
+                    batch_size: 16,
+                }
+                .to_settings(),
                 compressed_inputs: UseCompression::No,
                 compressed_outputs: UseCompression::Yes,
                 check_input_for_correctness: CheckForCorrectness::No,
@@ -693,7 +698,12 @@ impl Development {
     fn generate_namada_env(keypair: &KeyPair) -> Self {
         Self {
             environment: Environment {
-                parameters: Parameters::Namada { number_of_chunks: 1, power: 6, batch_size: 16 }.to_settings(),
+                parameters: Parameters::Namada {
+                    number_of_chunks: 1,
+                    power: 6,
+                    batch_size: 16,
+                }
+                .to_settings(),
                 compressed_inputs: UseCompression::No,
                 compressed_outputs: UseCompression::Yes,
                 check_input_for_correctness: CheckForCorrectness::No,
@@ -826,7 +836,12 @@ impl Production {
     fn generate_namada_env(keypair: &KeyPair) -> Self {
         Self {
             environment: Environment {
-                parameters: Parameters::Namada { number_of_chunks: 1, power: 6, batch_size: 16 }.to_settings(),
+                parameters: Parameters::Namada {
+                    number_of_chunks: 1,
+                    power: 6,
+                    batch_size: 16,
+                }
+                .to_settings(),
                 compressed_inputs: UseCompression::No,
                 compressed_outputs: UseCompression::Yes,
                 check_input_for_correctness: CheckForCorrectness::No,
@@ -855,7 +870,7 @@ impl Production {
                 local_base_directory: "./transcript".to_string(),
 
                 disable_reliability_zeroing: false,
-            }
+            },
         }
     }
 

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -5,8 +5,6 @@ use setup_utils::{CheckForCorrectness, UseCompression};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
 
-use std::fs;
-
 type BatchSize = usize;
 type ChunkSize = usize;
 type NumberOfChunks = usize;

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -510,7 +510,7 @@ impl From<Production> for Environment {
 
 /// Generate keypair for the default verifier of coordinator and writes it to file
 fn generate_keypair() -> anyhow::Result<KeyPair> {
-    let keypair = KeyPair::new();
+    let keypair = KeyPair::new(); //FIXME: use mnemonic!!! Need to pass some parameters to the command to run the coordinator
     fs::write(COORDINATOR_KEYPAIR_FILE, serde_json::to_vec(&keypair)?)?;
 
     Ok(keypair)

--- a/phase1-coordinator/src/environment.rs
+++ b/phase1-coordinator/src/environment.rs
@@ -510,7 +510,7 @@ impl From<Production> for Environment {
 
 /// Generate keypair for the default verifier of coordinator and writes it to file
 fn generate_keypair() -> anyhow::Result<KeyPair> {
-    let keypair = KeyPair::new(); //FIXME: use mnemonic!!! Need to pass some parameters to the command to run the coordinator
+    let keypair = KeyPair::new(); //FIXME: use mnemonic!!!
     fs::write(COORDINATOR_KEYPAIR_FILE, serde_json::to_vec(&keypair)?)?;
 
     Ok(keypair)

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -1,5 +1,4 @@
 use crate::authentication::KeyPair;
-use rand::Rng;
 use regex::Regex;
 use bip39::{Language, Mnemonic};
 use thiserror::Error;

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -1,0 +1,90 @@
+use crate::authentication::KeyPair;
+use rand::Rng;
+use rand::distributions::{Distribution, Uniform};
+use regex::Regex;
+use bip39::{Language, Mnemonic};
+use thiserror::Error;
+use tracing::debug;
+
+const MNEMONIC_LEN: usize = 24;
+const MNEMONIC_CHECK_LEN: usize = 3;
+
+#[derive(Debug, Error)]
+pub enum IOError {
+    #[error("Wrong answer in mnemonic check")]
+    CheckMnemonicError,
+    #[error("Error in user input: {0}")]
+    InputError(#[from] std::io::Error),
+    #[error("Error in KeyPair generation: {0}")]
+    KeyPairError(#[from] ed25519_compact::Error),
+    #[error("Mnemonic error: {0}")]
+    MnemonicError(bip39::Error),
+    #[error("Regex error: {0}")]
+    RegexError(#[from] regex::Error),
+}
+
+type Result<T> = std::result::Result<T, IOError>;
+
+/// Helper function to get input from the user. Accept an optional [`Regex`] to
+/// check the validity of the reply
+pub fn get_user_input(request: &str, expected: Option<&Regex>) -> Result<String> {
+    let mut response = String::new();
+
+    loop {
+        println!("{}", request);
+        std::io::stdin().read_line(&mut response)?;
+        response = response.trim().to_owned();
+
+        match expected {
+            Some(re) => {
+                if re.is_match(response.as_str()) {
+                    break;
+                }
+            },
+            None => break,
+        }
+
+        response.clear();
+        println!("Invalid reply, please answer again...");
+    }
+
+    Ok(response)
+}
+
+/// Generates a new [`KeyPair`] from a mnemonic provided by the user
+pub fn generate_keypair() -> Result<KeyPair> {
+    // Request mnemonic to the user
+    let mnemonic_str = get_user_input(format!("Please provide a {} words mnemonic for your keypair:", MNEMONIC_LEN).as_str(), Some(&Regex::new(r"^([[:alpha:]]+\s){23}[[:alpha:]]+$")?))?;
+    let mnemonic = Mnemonic::parse_in_normalized(Language::English, mnemonic_str.as_str()).map_err(|e| {IOError::MnemonicError(e)})?;
+
+    // FIXME: add unit tests for regex (proptest?)
+
+    // Check if the user has correctly stored the mnemonic
+    check_mnemonic(&mnemonic)?;
+
+    let seed = mnemonic.to_seed_normalized("");
+    Ok(KeyPair::try_from_seed(&seed)?)
+}
+
+/// Interactively check if the user has correctly stored the mnemonic phrase
+fn check_mnemonic(mnemonic: &Mnemonic) -> Result<()> { //FIXME: improve prints
+    let rng = rand::thread_rng();
+    let uniform = Uniform::from(1..MNEMONIC_LEN);
+    let random_indexes: Vec<usize> = uniform.sample_iter(rng).take(MNEMONIC_CHECK_LEN).collect(); //FIXME: this could get the same number more than once, check uniqueness of the index extracted
+
+    println!("Mnemonic verification step");
+    let mnemonic_slice: Vec<&'static str> = mnemonic.word_iter().collect();
+
+    for i in random_indexes {
+       let response = get_user_input(format!("Enter the word at index {} of your mnemonic:", i).as_str(), Some(&Regex::new(r"[[:alpha:]]+")?))?;
+ 
+        if response != mnemonic_slice[i - 1] {
+            debug!("Expected: {}, answer: {}", mnemonic_slice[i - 1], response);
+            return Err(IOError::CheckMnemonicError);
+        }
+    }
+
+    println!("Verification passed. Be sure to safely store your mnemonic phrase!");
+
+    Ok(())
+}

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -4,6 +4,7 @@ use regex::Regex;
 use bip39::{Language, Mnemonic};
 use thiserror::Error;
 use tracing::debug;
+use rand::prelude::SliceRandom;
 
 const MNEMONIC_LEN: usize = 24;
 const MNEMONIC_CHECK_LEN: usize = 3;

--- a/phase1-coordinator/src/io.rs
+++ b/phase1-coordinator/src/io.rs
@@ -65,7 +65,8 @@ pub fn generate_keypair(from_mnemonic: bool) -> Result<KeyPair> {
     } else {
         // Generate random mnemonic
         let mut rng = rand_06::thread_rng();
-        let mnemonic = Mnemonic::generate_in_with(&mut rng, Language::English, MNEMONIC_LEN).map_err(|e| IOError::MnemonicError(e))?;
+        let mnemonic = Mnemonic::generate_in_with(&mut rng, Language::English, MNEMONIC_LEN)
+            .map_err(|e| IOError::MnemonicError(e))?;
 
         // Print mnemonic to the user
         println!("Safely store your 24 words mnemonic: {}", mnemonic);

--- a/phase1-coordinator/src/lib.rs
+++ b/phase1-coordinator/src/lib.rs
@@ -46,7 +46,7 @@ pub mod coordinator_state;
 pub use coordinator_state::CoordinatorState;
 
 pub mod environment;
-pub use environment::COORDINATOR_KEYPAIR_FILE;
+pub mod io;
 
 pub mod objects;
 pub use objects::{ContributionFileSignature, ContributionState, Participant, Round};

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -46,7 +46,7 @@ pub async fn main() {
     tracing_subscriber::fmt::init();
 
     // Set the environment
-    let keypair = tokio::task::spawn_blocking(io::generate_keypair)
+    let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(false)})
         .await
         .unwrap()
         .expect("Error while generating the keypair");

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -1,6 +1,7 @@
 use phase1_coordinator::{
     authentication::Production as ProductionSig,
     environment::Parameters,
+    io,
     rest::{self, UPDATE_TIME},
     Coordinator,
 };
@@ -59,7 +60,12 @@ pub async fn main() {
     };
 
     #[cfg(not(debug_assertions))]
-    let environment: Production = Production::from(parameters);
+    let environment: Production = {
+        // Generate KeyPair
+        let keypair = io::generate_keypair().expect("Error while generating the keypair");
+
+        Production::new(parameters, &keypair)
+    };
 
     // Instantiate and start the coordinator
     let coordinator =

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -1,6 +1,5 @@
 use phase1_coordinator::{
     authentication::Production as ProductionSig,
-    environment::Parameters,
     io,
     rest::{self , UPDATE_TIME},
     Coordinator,
@@ -21,7 +20,7 @@ use rocket::{
 use anyhow::Result;
 use std::sync::Arc;
 
-use tracing::{debug, error, info};
+use tracing::{error, info};
 
 /// Periodically updates the [`Coordinator`]
 async fn update_coordinator(coordinator: Arc<RwLock<Coordinator>>) -> Result<()> {

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -88,7 +88,9 @@ pub async fn main() {
         rest::get_tasks_left,
         rest::stop_coordinator,
         rest::verify_chunks,
-        rest::get_contributor_queue_status
+        rest::get_contributor_queue_status,
+        rest::post_contribution_info,
+        rest::get_contributions_info
     ];
 
     #[cfg(not(debug_assertions))]
@@ -102,7 +104,9 @@ pub async fn main() {
         rest::heartbeat,
         rest::get_tasks_left,
         rest::stop_coordinator,
-        rest::get_contributor_queue_status
+        rest::get_contributor_queue_status,
+        rest::post_contribution_info,
+        rest::get_contributions_info
     ];
 
     let build_rocket = rocket::build().mount("/", routes).manage(coordinator);

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -1,7 +1,7 @@
 use phase1_coordinator::{
     authentication::Production as ProductionSig,
     io,
-    rest::{self , UPDATE_TIME},
+    rest::{self, UPDATE_TIME},
     Coordinator,
 };
 
@@ -46,7 +46,10 @@ pub async fn main() {
     tracing_subscriber::fmt::init();
 
     // Set the environment
-    let keypair = tokio::task::spawn_blocking(io::generate_keypair).await.unwrap().expect("Error while generating the keypair");
+    let keypair = tokio::task::spawn_blocking(io::generate_keypair)
+        .await
+        .unwrap()
+        .expect("Error while generating the keypair");
 
     #[cfg(debug_assertions)]
     let environment: Testing = {
@@ -55,9 +58,7 @@ pub async fn main() {
     };
 
     #[cfg(not(debug_assertions))]
-    let environment: Production = {
-        Production::new(&keypair)
-    };
+    let environment: Production = { Production::new(&keypair) };
 
     // Instantiate and start the coordinator
     let coordinator =

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -46,7 +46,7 @@ pub async fn main() {
     tracing_subscriber::fmt::init();
 
     // Set the environment
-    let keypair = tokio::task::spawn_blocking(|| {io::generate_keypair(false)})
+    let keypair = tokio::task::spawn_blocking(|| io::generate_keypair(false))
         .await
         .unwrap()
         .expect("Error while generating the keypair");

--- a/phase1-coordinator/src/main.rs
+++ b/phase1-coordinator/src/main.rs
@@ -2,7 +2,7 @@ use phase1_coordinator::{
     authentication::Production as ProductionSig,
     environment::Parameters,
     io,
-    rest::{self, CONTRIBUTORS_INFO_FOLDER, UPDATE_TIME},
+    rest::{self , UPDATE_TIME},
     Coordinator,
 };
 
@@ -15,7 +15,7 @@ use phase1_coordinator::environment::Production;
 use rocket::{
     self,
     routes,
-    tokio::{self, fs, sync::RwLock},
+    tokio::{self, sync::RwLock},
 };
 
 use anyhow::Result;
@@ -59,11 +59,6 @@ pub async fn main() {
     let environment: Production = {
         Production::new(&keypair)
     };
-
-    // Create required folder for contributors' info FIXME:
-    if fs::metadata(CONTRIBUTORS_INFO_FOLDER).await.is_err() {
-        fs::create_dir(CONTRIBUTORS_INFO_FOLDER).await.unwrap();
-    }
 
     // Instantiate and start the coordinator
     let coordinator =

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -75,8 +75,8 @@ pub struct ContributionInfo {
    pub contribution_file_signature: String,
    // Some timestamps to get performance metrics of the ceremony
    pub timestamps: ContributionTimeStamps,
-   // Signature of this struct
-   pub contributor_info_signature: String //FIXME: computes that on the json encoding
+   // Signature of this struct, computed on the json string encoding of all the other fields of this struct
+   pub contributor_info_signature: String
 }
 
 /// A summarized version of [`ContributionInfo`]

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -32,13 +32,13 @@ impl Default for ContributionTimeStamps {
 
 /// A summarized version of [`ContributionTimeStamps`] 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct TrimmedContributionTimeStamps { //FIXME: include in other struct?
+pub struct TrimmedContributionTimeStamps {
     start_contribution: DateTime<Utc>,
     end_contribution: DateTime<Utc>
 }
 
-impl From<&ContributionTimeStamps> for TrimmedContributionTimeStamps {
-    fn from(parent: &ContributionTimeStamps) -> Self {
+impl From<ContributionTimeStamps> for TrimmedContributionTimeStamps {
+    fn from(parent: ContributionTimeStamps) -> Self {
         Self {
             start_contribution: parent.start_contribution,
             end_contribution: parent.end_contribution
@@ -91,8 +91,8 @@ pub struct TrimmedContributionInfo {
     timestamps: TrimmedContributionTimeStamps
 }
 
-impl From<&ContributionInfo> for TrimmedContributionInfo {
-    fn from(parent: &ContributionInfo) -> Self {
+impl From<ContributionInfo> for TrimmedContributionInfo {
+    fn from(parent: ContributionInfo) -> Self {
         Self {
             public_key: parent.public_key,
             is_another_machine: parent.is_another_machine,

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -1,0 +1,106 @@
+use chrono::{DateTime, Utc};
+use serde::{Serialize, Deserialize};
+use serde_json::Error;
+
+/// Timestamps of the contribution 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ContributionTimeStamps {
+    // User starts the CLI
+    pub start_contribution: DateTime<Utc>,
+    // User has joined the queue
+    pub joined_queue: DateTime<Utc>,
+    // User has locked the challenge on the coordinator
+    pub challenge_locked: DateTime<Utc>,
+    // User has completed the download of the challenge
+    pub challenge_downloaded: DateTime<Utc>,
+    // User starts computation locally or downloads the file to another machine
+    pub start_computation: DateTime<Utc>,
+    // User finishes computation locally or uploads the file from another machine
+    pub end_computation: DateTime<Utc>,
+    // User attests that the file was uploaded correctly
+    pub end_contribution: DateTime<Utc>
+}
+
+impl Default for ContributionTimeStamps {
+    /// Generate a [`ContributionTimeStamps`] instance with all the timestamps 
+    /// set to [`Utc::now`].
+    fn default() -> Self {
+        let timestamp = Utc::now();
+        Self { start_contribution: timestamp, joined_queue: timestamp, challenge_locked: timestamp, challenge_downloaded: timestamp, start_computation: timestamp, end_computation: timestamp, end_contribution: timestamp }
+    }
+}
+
+/// A summarized version of [`ContributionTimeStamps`] 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrimmedContributionTimeStamps { //FIXME: include in other struct?
+    start_contribution: DateTime<Utc>,
+    end_contribution: DateTime<Utc>
+}
+
+impl From<&ContributionTimeStamps> for TrimmedContributionTimeStamps {
+    fn from(parent: &ContributionTimeStamps) -> Self {
+        Self {
+            start_contribution: parent.start_contribution,
+            end_contribution: parent.end_contribution
+        }
+    }
+}
+
+/// Summary info about the contribution
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct ContributionInfo {
+    // Name of the contributor
+    pub full_name: Option<String>,
+    // Email of the contributor
+    pub email: Option<String>,
+   // ed25519 public key, base64 encoded
+   pub public_key: String,
+   // User participates in incentivized program or not
+   pub is_incentivized: bool,
+   // User expresses his intent to participate or not in the contest for creative contributions
+   pub is_contest_participant: bool,
+   // User can choose to contribute on another machine
+   pub is_another_machine: bool,
+   // User can choose the default method to generate randomness or his own.
+   pub is_own_seed_of_randomness: bool,
+   // Round in which the contribution took place
+   pub ceremony_round: u64,
+   // Hash of the contribution run by masp-mpc, contained in the transcript
+   pub contribution_hash: String,
+   // Signature of the contribution hash
+   pub contribution_hash_signature: String,
+   // Hash of the file saved on disk and sent to the coordinator
+   pub contribution_file_hash: String,
+   // Signature of the contribution
+   pub contribution_file_signature: String,
+   // Some timestamps to get performance metrics of the ceremony
+   pub timestamps: ContributionTimeStamps,
+   // Signature of this struct
+   pub contributor_info_signature: String //FIXME: computes that on the json encoding
+}
+
+/// A summarized version of [`ContributionInfo`]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TrimmedContributionInfo {
+    public_key: String,
+    is_another_machine: bool,
+    is_own_seed_of_randomness: bool,
+    ceremony_round: u64,
+    contribution_hash: String,
+    contribution_hash_signature: String,
+    timestamps: TrimmedContributionTimeStamps
+}
+
+impl From<&ContributionInfo> for TrimmedContributionInfo {
+    fn from(parent: &ContributionInfo) -> Self {
+        Self {
+            public_key: parent.public_key,
+            is_another_machine: parent.is_another_machine,
+            is_own_seed_of_randomness: parent.is_own_seed_of_randomness,
+            ceremony_round: parent.ceremony_round,
+            contribution_hash: parent.contribution_hash,
+            contribution_hash_signature: parent.contribution_hash_signature,
+            timestamps: parent.timestamps.into()
+        }
+    }
+}

--- a/phase1-coordinator/src/objects/contribution_info.rs
+++ b/phase1-coordinator/src/objects/contribution_info.rs
@@ -1,8 +1,8 @@
-use crate::authentication::{Production, Signature, KeyPair};
+use crate::authentication::{KeyPair, Production, Signature};
 
 use chrono::{DateTime, Utc};
-use serde::{Serialize, Deserialize};
-use sha2::{Sha256, Digest};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -17,7 +17,7 @@ pub enum ContributionInfoError {
     UnexpectedSerializationFormat,
 }
 
-/// Timestamps of the contribution 
+/// Timestamps of the contribution
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ContributionTimeStamps {
     // User starts the CLI
@@ -33,30 +33,38 @@ pub struct ContributionTimeStamps {
     // User finishes computation locally or uploads the file from another machine
     pub end_computation: DateTime<Utc>,
     // User attests that the file was uploaded correctly
-    pub end_contribution: DateTime<Utc>
+    pub end_contribution: DateTime<Utc>,
 }
 
 impl Default for ContributionTimeStamps {
-    /// Generate a [`ContributionTimeStamps`] instance with all the timestamps 
+    /// Generate a [`ContributionTimeStamps`] instance with all the timestamps
     /// set to [`Utc::now`].
     fn default() -> Self {
         let timestamp = Utc::now();
-        Self { start_contribution: timestamp, joined_queue: timestamp, challenge_locked: timestamp, challenge_downloaded: timestamp, start_computation: timestamp, end_computation: timestamp, end_contribution: timestamp }
+        Self {
+            start_contribution: timestamp,
+            joined_queue: timestamp,
+            challenge_locked: timestamp,
+            challenge_downloaded: timestamp,
+            start_computation: timestamp,
+            end_computation: timestamp,
+            end_contribution: timestamp,
+        }
     }
 }
 
-/// A summarized version of [`ContributionTimeStamps`] 
+/// A summarized version of [`ContributionTimeStamps`]
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct TrimmedContributionTimeStamps {
     start_contribution: DateTime<Utc>,
-    end_contribution: DateTime<Utc>
+    end_contribution: DateTime<Utc>,
 }
 
 impl From<ContributionTimeStamps> for TrimmedContributionTimeStamps {
     fn from(parent: ContributionTimeStamps) -> Self {
         Self {
             start_contribution: parent.start_contribution,
-            end_contribution: parent.end_contribution
+            end_contribution: parent.end_contribution,
         }
     }
 }
@@ -68,30 +76,30 @@ pub struct ContributionInfo {
     pub full_name: Option<String>,
     // Email of the contributor
     pub email: Option<String>,
-   // ed25519 public key, base64 encoded
-   pub public_key: String,
-   // User participates in incentivized program or not
-   pub is_incentivized: bool,
-   // User expresses his intent to participate or not in the contest for creative contributions
-   pub is_contest_participant: bool,
-   // User can choose to contribute on another machine
-   pub is_another_machine: bool,
-   // User can choose the default method to generate randomness or his own.
-   pub is_own_seed_of_randomness: bool,
-   // Round in which the contribution took place
-   pub ceremony_round: u64,
-   // Hash of the contribution run by masp-mpc, contained in the transcript
-   pub contribution_hash: String,
-   // Signature of the contribution hash
-   pub contribution_hash_signature: String,
-   // Hash of the file saved on disk and sent to the coordinator
-   pub contribution_file_hash: String,
-   // Signature of the contribution
-   pub contribution_file_signature: String,
-   // Some timestamps to get performance metrics of the ceremony
-   pub timestamps: ContributionTimeStamps,
-   // Signature of this struct, computed on the json string encoding of all the other fields of this struct
-   pub contributor_info_signature: String
+    // ed25519 public key, base64 encoded
+    pub public_key: String,
+    // User participates in incentivized program or not
+    pub is_incentivized: bool,
+    // User expresses his intent to participate or not in the contest for creative contributions
+    pub is_contest_participant: bool,
+    // User can choose to contribute on another machine
+    pub is_another_machine: bool,
+    // User can choose the default method to generate randomness or his own.
+    pub is_own_seed_of_randomness: bool,
+    // Round in which the contribution took place
+    pub ceremony_round: u64,
+    // Hash of the contribution run by masp-mpc, contained in the transcript
+    pub contribution_hash: String,
+    // Signature of the contribution hash
+    pub contribution_hash_signature: String,
+    // Hash of the file saved on disk and sent to the coordinator
+    pub contribution_file_hash: String,
+    // Signature of the contribution
+    pub contribution_file_signature: String,
+    // Some timestamps to get performance metrics of the ceremony
+    pub timestamps: ContributionTimeStamps,
+    // Signature of this struct, computed on the json string encoding of all the other fields of this struct
+    pub contributor_info_signature: String,
 }
 
 impl ContributionInfo {
@@ -101,7 +109,9 @@ impl ContributionInfo {
         let mut serde_contrib_info = serde_json::to_value(self.clone())?;
 
         // Remove contributor_info_signature from json
-        let map = serde_contrib_info.as_object_mut().ok_or(ContributionInfoError::UnexpectedSerializationFormat)?;
+        let map = serde_contrib_info
+            .as_object_mut()
+            .ok_or(ContributionInfoError::UnexpectedSerializationFormat)?;
         map.remove("contributor_info_signature");
         let serialized_contrib_info = serde_contrib_info.to_string();
 
@@ -112,7 +122,7 @@ impl ContributionInfo {
         Ok(format!("{:x?}", hasher.finalize()))
     }
 
-    /// Computes the signature of a json string encoding the struct. 
+    /// Computes the signature of a json string encoding the struct.
     pub fn try_sign(&mut self, keypair: &KeyPair) -> Result<(), ContributionInfoError> {
         let digest = self.hash_for_signature()?;
 
@@ -122,7 +132,9 @@ impl ContributionInfo {
             return Err(ContributionInfoError::InvalidSigKey);
         }
 
-        let contrib_info_signature = Production.sign(keypair.sigkey(), digest.as_str()).map_err(|e| ContributionInfoError::SignatureError(format!("{}", e)))?;
+        let contrib_info_signature = Production
+            .sign(keypair.sigkey(), digest.as_str())
+            .map_err(|e| ContributionInfoError::SignatureError(format!("{}", e)))?;
         self.contributor_info_signature = contrib_info_signature;
 
         Ok(())
@@ -132,8 +144,12 @@ impl ContributionInfo {
     #[cfg(debug_assertions)]
     fn verify_signature(&self) -> Result<bool, ContributionInfoError> {
         let serialized_contrib_info = self.hash_for_signature()?;
-        
-        Ok(Production.verify(self.public_key.as_str(), serialized_contrib_info.as_str(), self.contributor_info_signature.as_str()))
+
+        Ok(Production.verify(
+            self.public_key.as_str(),
+            serialized_contrib_info.as_str(),
+            self.contributor_info_signature.as_str(),
+        ))
     }
 }
 
@@ -146,7 +162,7 @@ pub struct TrimmedContributionInfo {
     ceremony_round: u64,
     contribution_hash: String,
     contribution_hash_signature: String,
-    timestamps: TrimmedContributionTimeStamps
+    timestamps: TrimmedContributionTimeStamps,
 }
 
 impl From<ContributionInfo> for TrimmedContributionInfo {
@@ -158,7 +174,7 @@ impl From<ContributionInfo> for TrimmedContributionInfo {
             ceremony_round: parent.ceremony_round,
             contribution_hash: parent.contribution_hash,
             contribution_hash_signature: parent.contribution_hash_signature,
-            timestamps: parent.timestamps.into()
+            timestamps: parent.timestamps.into(),
         }
     }
 }

--- a/phase1-coordinator/src/objects/mod.rs
+++ b/phase1-coordinator/src/objects/mod.rs
@@ -7,6 +7,9 @@ pub use contribution::*;
 pub mod contribution_file_signature;
 pub use contribution_file_signature::*;
 
+pub mod contribution_info;
+pub use contribution_info::*;
+
 pub mod participant;
 pub use participant::*;
 

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -6,6 +6,9 @@ use crate::{
     storage::{ContributionLocator, ContributionSignatureLocator},
     ContributionFileSignature,
 };
+
+pub use crate::objects::{ContributionInfo, TrimmedContributionInfo};
+
 use rocket::{
     error,
     get,
@@ -27,7 +30,6 @@ use crate::{objects::LockedLocators, CoordinatorError, Participant};
 
 use std::{collections::{LinkedList, HashMap}, io::Cursor, fs, net::SocketAddr, ops::Deref, sync::Arc, time::Duration};
 use thiserror::Error;
-use chrono::{DateTime, Utc};
 
 use tracing::debug;
 
@@ -187,109 +189,6 @@ impl PostChunkRequest {
             contribution,
             contribution_file_signature_locator,
             contribution_file_signature,
-        }
-    }
-}
-
-/// Timestamps of the contribution 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct ContributionTimeStamps {
-    // User starts the CLI
-    pub start_contribution: DateTime<Utc>,
-    // User has joined the queue
-    pub joined_queue: DateTime<Utc>,
-    // User has locked the challenge on the coordinator
-    pub challenge_locked: DateTime<Utc>,
-    // User has completed the download of the challenge
-    pub challenge_downloaded: DateTime<Utc>,
-    // User starts computation locally or downloads the file to another machine
-    pub start_computation: DateTime<Utc>,
-    // User finishes computation locally or uploads the file from another machine
-    pub end_computation: DateTime<Utc>,
-    // User attests that the file was uploaded correctly
-    pub end_contribution: DateTime<Utc>
-}
-
-impl Default for ContributionTimeStamps {
-    /// Generate a [`ContributionTimeStamps`] instance with all the timestamps 
-    /// set to [`Utc::now`].
-    fn default() -> Self {
-        let timestamp = Utc::now();
-        Self { start_contribution: timestamp, joined_queue: timestamp, challenge_locked: timestamp, challenge_downloaded: timestamp, start_computation: timestamp, end_computation: timestamp, end_contribution: timestamp }
-    }
-}
-
-/// A summarized version of [`ContributionTimeStamps`] 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct TrimmedContributionTimeStamps {
-    start_contribution: DateTime<Utc>,
-    end_contribution: DateTime<Utc>
-}
-
-impl From<ContributionTimeStamps> for TrimmedContributionTimeStamps {
-    fn from(parent: ContributionTimeStamps) -> Self {
-        Self {
-            start_contribution: parent.start_contribution,
-            end_contribution: parent.end_contribution
-        }
-    }
-}
-
-/// Summary info about the contribution
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct ContributionInfo {
-    // Name of the contributor
-    pub full_name: Option<String>,
-    // Email of the contributor
-    pub email: Option<String>,
-   // ed25519 public key, base64 encoded
-   pub public_key: String,
-   // User participates in incentivized program or not
-   pub is_incentivized: bool,
-   // User expresses his intent to participate or not in the contest for creative contributions
-   pub is_contest_participant: bool,
-   // User can choose to contribute on another machine
-   pub is_another_machine: bool,
-   // User can choose the default method to generate randomness or his own.
-   pub is_own_seed_of_randomness: bool,
-   // Round in which the contribution took place
-   pub ceremony_round: u64,
-   // Hash of the contribution run by masp-mpc, contained in the transcript
-   pub contribution_hash: String,
-   // FIXME: is this necessary? so other user can check the contribution hash against the public key?
-   pub contribution_hash_signature: String,
-   // Hash of the file saved on disk and sent to the coordinator
-   pub contribution_file_hash: String, //FIXME: what's the difference with contribution_hash?
-   // Signature of the contribution
-   pub contribution_file_signature: String, //FIXME: what's the difference with contribution_hash_signature?
-   // Some timestamps to get performance metrics of the ceremony
-   pub timestamps: ContributionTimeStamps,
-   // Signature of this struct
-   pub contributor_info_signature: String //FIXME: necessary? Requests are already signed
-}
-
-/// A summarized version of [`ContributionInfo`]
-#[derive(Debug, Deserialize, Serialize)]
-pub struct TrimmedContributionInfo {
-    public_key: String,
-    is_another_machine: bool,
-    is_own_seed_of_randomness: bool,
-    ceremony_round: u64,
-    contribution_hash: String,
-    contribution_hash_signature: String,
-    timestamps: TrimmedContributionTimeStamps
-}
-
-impl From<ContributionInfo> for TrimmedContributionInfo {
-    fn from(parent: ContributionInfo) -> Self {
-        Self {
-            public_key: parent.public_key,
-            is_another_machine: parent.is_another_machine,
-            is_own_seed_of_randomness: parent.is_own_seed_of_randomness,
-            ceremony_round: parent.ceremony_round,
-            contribution_hash: parent.contribution_hash,
-            contribution_hash_signature: parent.contribution_hash_signature,
-            timestamps: parent.timestamps.into()
         }
     }
 }

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -571,19 +571,11 @@ pub async fn post_contribution_info(
     Ok(())
 }
 
-/// Retrieve the contributions' info. This endpoint is accessible only by the coordinator itself.
-#[get("/contribution_info", format = "json", data = "<request>")]
+/// Retrieve the contributions' info. This endpoint is accessible by anyone and does not require a signed request.
+#[get("/contribution_info", format = "json")]
 pub async fn get_contributions_info(
     coordinator: &State<Coordinator>,
-    request: Json<SignedRequest<()>>,
 ) -> Result<Json<Vec<TrimmedContributionInfo>>> {
-    let signed_request = request.into_inner();
-
-    // Verify request
-    signed_request
-        .check_coordinator_request(coordinator, "/contribution_info")
-        .await?;
-
     let read_lock = (*coordinator).clone().read_owned().await;
     let summary = match task::spawn_blocking(move || read_lock.storage().get(&Locator::ContributionsInfoSummary))
         .await?

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -137,7 +137,8 @@ impl<T: Serialize> SignedRequest<T> {
     /// Returns a signed request
     pub fn try_sign(keypair: &KeyPair, request: Option<T>) -> Result<Self> {
         let mut message = json::to_string(&keypair.pubkey().to_owned())?;
-
+        // FIXME: is it correct to concatenate the strings? Better to create a Value?
+        // FIXME: sign the hash of the json encoding string
         // If body is non-empty add it to the message to be signed
         if let Some(ref r) = request {
             message.push_str(json::to_string(r)?.as_str());

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -573,9 +573,7 @@ pub async fn post_contribution_info(
 
 /// Retrieve the contributions' info. This endpoint is accessible by anyone and does not require a signed request.
 #[get("/contribution_info", format = "json")]
-pub async fn get_contributions_info(
-    coordinator: &State<Coordinator>,
-) -> Result<Json<Vec<TrimmedContributionInfo>>> {
+pub async fn get_contributions_info(coordinator: &State<Coordinator>) -> Result<Json<Vec<TrimmedContributionInfo>>> {
     let read_lock = (*coordinator).clone().read_owned().await;
     let summary = match task::spawn_blocking(move || read_lock.storage().get(&Locator::ContributionsInfoSummary))
         .await?

--- a/phase1-coordinator/src/rest.rs
+++ b/phase1-coordinator/src/rest.rs
@@ -546,7 +546,11 @@ pub async fn post_contribution_info(
     let contributor_clone = contributor.clone();
     let read_lock = (*coordinator).clone().read_owned().await;
 
-    if !task::spawn_blocking(move || read_lock.is_current_contributor(&contributor_clone)).await? {
+    if !task::spawn_blocking(move || {
+        read_lock.is_current_contributor(&contributor_clone) || read_lock.is_finished_contributor(&contributor_clone)
+    })
+    .await?
+    {
         // Only the current contributor can upload this file
         return Err(ResponseError::UnauthorizedParticipant(
             contributor,

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -1,11 +1,18 @@
 use crate::{
     environment::Environment,
-    objects::{ContributionFileSignature, Round, ContributionInfo, TrimmedContributionInfo},
+    objects::{ContributionFileSignature, ContributionInfo, Round, TrimmedContributionInfo},
     storage::{
-        ContributionLocator, ContributionSignatureLocator, Locator, Object, ObjectReader, ObjectWriter, StorageLocator,
+        ContributionLocator,
+        ContributionSignatureLocator,
+        Locator,
+        Object,
+        ObjectReader,
+        ObjectWriter,
+        StorageLocator,
         StorageObject,
     },
-    CoordinatorError, CoordinatorState,
+    CoordinatorError,
+    CoordinatorState,
 };
 
 use anyhow::Result;
@@ -61,7 +68,10 @@ impl Disk {
 
         // Create the contributions summary locator if it does not exist yet.
         if !storage.exists(&Locator::ContributionsInfoSummary) {
-            storage.insert(Locator::ContributionsInfoSummary, Object::ContributionsInfoSummary(vec![]))?;
+            storage.insert(
+                Locator::ContributionsInfoSummary,
+                Object::ContributionsInfoSummary(vec![]),
+            )?;
         }
 
         trace!("Loaded disk storage");
@@ -204,11 +214,11 @@ impl Disk {
 
                 let contribution_file_signature: ContributionFileSignature = serde_json::from_slice(&file_bytes)?;
                 Ok(Object::ContributionFileSignature(contribution_file_signature))
-            },
+            }
             Locator::ContributionInfoFile { round_height: _ } => {
                 let contribution_info: ContributionInfo = serde_json::from_slice(&file_bytes)?;
                 Ok(Object::ContributionInfoFile(contribution_info))
-            },
+            }
             Locator::ContributionsInfoSummary => {
                 let summary: Vec<TrimmedContributionInfo> = serde_json::from_slice(&file_bytes)?;
                 Ok(Object::ContributionsInfoSummary(summary))
@@ -647,8 +657,11 @@ impl StorageLocator for DiskResolver {
                     ),
                 }
             }
-            Locator::ContributionInfoFile { round_height } => format!("{}/contributors/namada_contributor_info_round_{}.json", self.base, round_height),
-            Locator::ContributionsInfoSummary => format!("{}/contributors.json", self.base)
+            Locator::ContributionInfoFile { round_height } => format!(
+                "{}/contributors/namada_contributor_info_round_{}.json",
+                self.base, round_height
+            ),
+            Locator::ContributionsInfoSummary => format!("{}/contributors.json", self.base),
         };
         // Sanitize the path.
         LocatorPath::try_from(Path::new(&path))

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::Environment,
-    objects::{ContributionFileSignature, Round},
+    objects::{ContributionFileSignature, Round, ContributionInfo, TrimmedContributionInfo},
     storage::{
         ContributionLocator, ContributionSignatureLocator, Locator, Object, ObjectReader, ObjectWriter, StorageLocator,
         StorageObject,
@@ -198,6 +198,14 @@ impl Disk {
 
                 let contribution_file_signature: ContributionFileSignature = serde_json::from_slice(&file_bytes)?;
                 Ok(Object::ContributionFileSignature(contribution_file_signature))
+            },
+            Locator::ContributionInfoFile { round_height: _ } => {
+                let contribution_info: ContributionInfo = serde_json::from_slice(&file_bytes)?;
+                Ok(Object::ContributionInfoFile(contribution_info))
+            },
+            Locator::ContributionsInfoSummary => {
+                let summary: Vec<TrimmedContributionInfo> = serde_json::from_slice(&file_bytes)?;
+                Ok(Object::ContributionsInfoSummary(summary))
             }
         };
 
@@ -633,6 +641,8 @@ impl StorageLocator for DiskResolver {
                     ),
                 }
             }
+            Locator::ContributionInfoFile { round_height } => format!("{}/contributors/namada_contributor_info_round_{}.json", self.base, round_height),
+            Locator::ContributionsInfoSummary => format!("{}/contributors.json", self.base)
         };
         // Sanitize the path.
         LocatorPath::try_from(Path::new(&path))

--- a/phase1-coordinator/src/storage/disk.rs
+++ b/phase1-coordinator/src/storage/disk.rs
@@ -38,10 +38,11 @@ impl Disk {
     {
         trace!("Loading disk storage");
 
-        // Check the base directory exists.
-        if !Path::new(environment.local_base_directory()).exists() {
-            // Create the base directory if it does not exist.
-            fs::create_dir_all(environment.local_base_directory()).expect("unable to create the base directory");
+        // Check the base and contribution info directory exist.
+        let contributors_dir = Path::new(environment.local_base_directory()).join("contributors");
+        if !contributors_dir.exists() {
+            // Create the base and contributors directory if they do not exist.
+            fs::create_dir_all(contributors_dir).expect("unable to create the contributors directory");
         }
 
         // Create a new `Storage` instance, and set the `Environment`.
@@ -56,6 +57,11 @@ impl Disk {
                 Locator::CoordinatorState,
                 Object::CoordinatorState(CoordinatorState::new(environment.clone())),
             )?;
+        }
+
+        // Create the contributions summary locator if it does not exist yet.
+        if !storage.exists(&Locator::ContributionsInfoSummary) {
+            storage.insert(Locator::ContributionsInfoSummary, Object::ContributionsInfoSummary(vec![]))?;
         }
 
         trace!("Loaded disk storage");

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -1,6 +1,6 @@
 use crate::{
     environment::Environment,
-    objects::{ContributionFileSignature, Round},
+    objects::{ContributionFileSignature, ContributionInfo, Round, TrimmedContributionInfo},
     CoordinatorError,
     CoordinatorState,
 };
@@ -106,6 +106,8 @@ pub enum Locator {
     RoundFile { round_height: u64 },
     ContributionFile(ContributionLocator),
     ContributionFileSignature(ContributionSignatureLocator),
+    ContributionInfoFile { round_height: u64 },
+    ContributionsInfoSummary
 }
 
 impl From<ContributionLocator> for Locator {
@@ -129,6 +131,8 @@ pub enum Object {
     RoundFile(Vec<u8>),
     ContributionFile(Vec<u8>),
     ContributionFileSignature(ContributionFileSignature),
+    ContributionInfoFile(ContributionInfo),
+    ContributionsInfoSummary(Vec<TrimmedContributionInfo>)
 }
 
 impl Object {
@@ -144,19 +148,14 @@ impl Object {
             Object::ContributionFileSignature(signature) => {
                 serde_json::to_vec_pretty(signature).expect("contribution file signature to bytes failed")
             }
+            Object::ContributionInfoFile(info) => serde_json::to_vec(info).expect("Contribution info file to bytes failed"),
+            Object::ContributionsInfoSummary(summary) => serde_json::to_vec(summary).expect("Contribution info summary to bytes failed")
         }
     }
 
     /// Returns the size in bytes of the object.
     pub fn size(&self) -> u64 {
-        match self {
-            Object::CoordinatorState(_) => self.to_bytes().len() as u64,
-            Object::RoundHeight(_) => self.to_bytes().len() as u64,
-            Object::RoundState(_) => self.to_bytes().len() as u64,
-            Object::RoundFile(round) => round.len() as u64,
-            Object::ContributionFile(contribution) => contribution.len() as u64,
-            Object::ContributionFileSignature(_) => self.to_bytes().len() as u64,
-        }
+        self.to_bytes().len() as u64
     }
 
     /// Returns the expected file size of an aggregated round.

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -107,7 +107,7 @@ pub enum Locator {
     ContributionFile(ContributionLocator),
     ContributionFileSignature(ContributionSignatureLocator),
     ContributionInfoFile { round_height: u64 },
-    ContributionsInfoSummary
+    ContributionsInfoSummary,
 }
 
 impl From<ContributionLocator> for Locator {
@@ -132,7 +132,7 @@ pub enum Object {
     ContributionFile(Vec<u8>),
     ContributionFileSignature(ContributionFileSignature),
     ContributionInfoFile(ContributionInfo),
-    ContributionsInfoSummary(Vec<TrimmedContributionInfo>)
+    ContributionsInfoSummary(Vec<TrimmedContributionInfo>),
 }
 
 impl Object {
@@ -148,8 +148,12 @@ impl Object {
             Object::ContributionFileSignature(signature) => {
                 serde_json::to_vec_pretty(signature).expect("contribution file signature to bytes failed")
             }
-            Object::ContributionInfoFile(info) => serde_json::to_vec(info).expect("Contribution info file to bytes failed"),
-            Object::ContributionsInfoSummary(summary) => serde_json::to_vec(summary).expect("Contribution info summary to bytes failed")
+            Object::ContributionInfoFile(info) => {
+                serde_json::to_vec(info).expect("Contribution info file to bytes failed")
+            }
+            Object::ContributionsInfoSummary(summary) => {
+                serde_json::to_vec(summary).expect("Contribution info summary to bytes failed")
+            }
         }
     }
 

--- a/phase1-coordinator/src/storage/storage.rs
+++ b/phase1-coordinator/src/storage/storage.rs
@@ -159,7 +159,16 @@ impl Object {
 
     /// Returns the size in bytes of the object.
     pub fn size(&self) -> u64 {
-        self.to_bytes().len() as u64
+        match self {
+            Object::CoordinatorState(_) => self.to_bytes().len() as u64,
+            Object::RoundHeight(_) => self.to_bytes().len() as u64,
+            Object::RoundState(_) => self.to_bytes().len() as u64,
+            Object::RoundFile(round) => round.len() as u64,
+            Object::ContributionFile(contribution) => contribution.len() as u64,
+            Object::ContributionFileSignature(_) => self.to_bytes().len() as u64,
+            Object::ContributionInfoFile(_) => self.to_bytes().len() as u64,
+            Object::ContributionsInfoSummary(_) => self.to_bytes().len() as u64,
+        }
     }
 
     /// Returns the expected file size of an aggregated round.

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -608,7 +608,12 @@ fn test_contribution() {
     contrib_info.full_name = Some(String::from("Test Name"));
     contrib_info.email = Some(String::from("test@mail.dev"));
     contrib_info.public_key = ctx.contributors[0].keypair.pubkey().to_owned();
-    contrib_info.ceremony_round = ctx.contributors[0].locked_locators.as_ref().unwrap().current_contribution().round_height();
+    contrib_info.ceremony_round = ctx.contributors[0]
+        .locked_locators
+        .as_ref()
+        .unwrap()
+        .current_contribution()
+        .round_height();
     contrib_info.try_sign(&ctx.contributors[0].keypair).unwrap();
 
     let sig_req = SignedRequest::try_sign(&ctx.contributors[0].keypair, Some(contrib_info)).unwrap();

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -500,19 +500,6 @@ fn test_wrong_post_contribution_info() {
     assert!(response.body().is_some());
 }
 
-#[test]
-fn test_wrong_get_contributions_info() {
-    let ctx = build_context();
-    let client = Client::tracked(ctx.rocket).expect("Invalid rocket instance");
-
-    // Wrong, request from non-coordinator participant
-    let sig_req = SignedRequest::<()>::try_sign(&ctx.contributors[0].keypair, None).unwrap();
-    let req = client.get("/contribution_info").json(&sig_req);
-    let response = req.dispatch();
-    assert_eq!(response.status(), Status::InternalServerError);
-    assert!(response.body().is_some());
-}
-
 /// To test a full contribution we need to test the 7 involved endpoints sequentially:
 ///
 /// - get_chunk
@@ -623,8 +610,7 @@ fn test_contribution() {
     assert!(response.body().is_none());
 
     // Get contributions info
-    let sig_req = SignedRequest::<()>::try_sign(&ctx.coordinator.keypair, None).unwrap();
-    req = client.get("/contribution_info").json(&sig_req);
+    req = client.get("/contribution_info");
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert!(response.body().is_some());

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -50,14 +50,8 @@ struct TestCtx {
 
 /// Build the rocket server for testing with the proper configuration.
 fn build_context() -> TestCtx {
-    let parameters = Parameters::TestAnoma {
-        number_of_chunks: 1,
-        power: 6,
-        batch_size: 16,
-    };
-
     // Reset storage to prevent state conflicts between tests and initialize test environment
-    let environment = coordinator::initialize_test_environment(&Testing::from(parameters).into());
+    let environment = coordinator::initialize_test_environment(&Testing::default().into());
 
     // Instantiate the coordinator
     let mut coordinator = Coordinator::new(environment, Arc::new(Production)).unwrap();
@@ -464,13 +458,14 @@ fn test_wrong_verify() {
     assert!(response.body().is_some());
 }
 
-/// To test a full contribution we need to test the 5 involved endpoints sequentially:
+/// To test a full contribution we need to test the 6 involved endpoints sequentially:
 ///
 /// - get_chunk
 /// - get_challenge
 /// - post_contribution_chunk
 /// - contribute_chunk
 /// - verify_chunk
+/// - get_contributions_info
 ///
 #[test]
 fn test_contribution() {
@@ -551,4 +546,6 @@ fn test_contribution() {
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
     assert!(response.body().is_none());
+
+    //FIXME: Get contributions info
 }

--- a/phase1-coordinator/tests/test_coordinator.rs
+++ b/phase1-coordinator/tests/test_coordinator.rs
@@ -113,7 +113,9 @@ fn build_context() -> TestCtx {
             rest::get_tasks_left,
             rest::stop_coordinator,
             rest::verify_chunks,
-            rest::get_contributor_queue_status
+            rest::get_contributor_queue_status,
+            rest::post_contribution_info,
+            rest::get_contributions_info
         ])
         .manage(coordinator);
 


### PR DESCRIPTION
- Fixes #11 
- Partially addresses #21 by implementing the first two interactions with the user
- Creates two new endpoints and their relative requests: `post_contribution_info` and `get_contributions_info`
- Adds the `get-contributions` CLI command
- Generates `KeyPair` from 24 words mnemonic
- Updates the Coordinator to store and retrieve the contributors' json files and the summary json file
- Create a default Namada environment (refactor)
- Fixes a `heartbeat` bug for which the first call to the endpoint happened before the `join_queue`
- Adds some more tests for the new endpoints